### PR TITLE
Corrected MessageGroupStart and MessageGroupEnd names

### DIFF
--- a/viser/_messages.py
+++ b/viser/_messages.py
@@ -297,12 +297,12 @@ class GuiSetLevaConfMessage(Message):
 
 
 @dataclasses.dataclass
-class MessageGroupStart(Message):
+class GroupStartMessage(Message):
     """Sent server->client to indicate the start of a message group."""
 
 
 @dataclasses.dataclass
-class MessageGroupEnd(Message):
+class GroupEndMessage(Message):
     """Sent server->client to indicate the end of a message group."""
 
 

--- a/viser/_viser.py
+++ b/viser/_viser.py
@@ -184,14 +184,14 @@ class ClientHandle(MessageApi):
             got_lock = False
         else:
             self._atomic_lock.acquire()
-            self._queue(_messages.MessageGroupStart())
+            self._queue(_messages.GroupStartMessage())
             self._locked_thread_id = thread_id
             got_lock = True
 
         yield
 
         if got_lock:
-            self._queue(_messages.MessageGroupEnd())
+            self._queue(_messages.GroupEndMessage())
             self._atomic_lock.release()
             self._locked_thread_id = -1
 
@@ -376,7 +376,7 @@ class ViserServer(MessageApi):
                 for client in self.get_clients().values():
                     stack.enter_context(client._atomic_lock)
 
-                self._queue(_messages.MessageGroupStart())
+                self._queue(_messages.GroupStartMessage())
 
             # There's a possible race condition here if we write something like:
             #
@@ -384,7 +384,7 @@ class ViserServer(MessageApi):
             #     client.add_frame(...)
             #
             # - We enter the server's atomic() context.
-            # - The server pushes a MessageGroupStart() to the broadcast buffer.
+            # - The server pushes a GroupStartMessage() to the broadcast buffer.
             # - The client pushes a frame message to the client buffer.
             # - For whatever reason the client buffer is handled before the broadcast
             # buffer.
@@ -395,6 +395,6 @@ class ViserServer(MessageApi):
             yield
 
         if got_lock:
-            self._queue(_messages.MessageGroupEnd())
+            self._queue(_messages.GroupEndMessage())
             self._atomic_lock.release()
             self._locked_thread_id = -1

--- a/viser/client/src/WebsocketMessages.tsx
+++ b/viser/client/src/WebsocketMessages.tsx
@@ -2,8 +2,7 @@
 // This file should not be manually modified.
 
 // For numpy arrays, we directly serialize the underlying data buffer.
-type ArrayBuffer = Uint8Array;
-interface ViewerCameraMessage {
+type ArrayBuffer = Uint8Array;interface ViewerCameraMessage {
   type: "ViewerCameraMessage";
   wxyz: [number, number, number, number];
   position: [number, number, number];
@@ -19,7 +18,7 @@ interface CameraFrustumMessage {
   aspect: number;
   scale: number;
   color: number;
-  image_media_type: "image/jpeg" | "image/png" | null;
+  image_media_type: 'image/jpeg' | 'image/png' | null;
   image_base64_data: string | null;
 }
 interface FrameMessage {
@@ -49,7 +48,7 @@ interface MeshMessage {
   color: number | null;
   vertex_colors: ArrayBuffer | null;
   wireframe: boolean;
-  side: "front" | "back" | "double";
+  side: 'front' | 'back' | 'double';
 }
 interface TransformControlsMessage {
   type: "TransformControlsMessage";
@@ -101,13 +100,13 @@ interface TransformControlsUpdateMessage {
 }
 interface BackgroundImageMessage {
   type: "BackgroundImageMessage";
-  media_type: "image/jpeg" | "image/png";
+  media_type: 'image/jpeg' | 'image/png';
   base64_data: string;
 }
 interface ImageMessage {
   type: "ImageMessage";
   name: string;
-  media_type: "image/jpeg" | "image/png";
+  media_type: 'image/jpeg' | 'image/png';
   base64_data: string;
   render_width: number;
   render_height: number;
@@ -154,18 +153,18 @@ interface GuiSetLevaConfMessage {
   name: string;
   leva_conf: any;
 }
-interface MessageGroupStart {
-  type: "MessageGroupStart";
+interface GroupStartMessage {
+  type: "GroupStartMessage";
 }
-interface MessageGroupEnd {
-  type: "MessageGroupEnd";
+interface GroupEndMessage {
+  type: "GroupEndMessage";
 }
 interface ThemeConfigurationMessage {
   type: "ThemeConfigurationMessage";
   canvas_background_color: number;
 }
 
-export type Message =
+export type Message = 
   | ViewerCameraMessage
   | CameraFrustumMessage
   | FrameMessage
@@ -191,6 +190,6 @@ export type Message =
   | GuiSetVisibleMessage
   | GuiSetValueMessage
   | GuiSetLevaConfMessage
-  | MessageGroupStart
-  | MessageGroupEnd
+  | GroupStartMessage
+  | GroupEndMessage
   | ThemeConfigurationMessage;


### PR DESCRIPTION
#36 
I corrected naming in `_messages.py`:
MessageGroupEnd  -> GroupStartMessage
MessageGroupEnd  -> GroupEndMessage

At the same time I corrected referencing instances in `viser.py` to new names.