### PR TITLE
Add argument for automatic TCP tunneling

### DIFF
--- a/examples/00_coordinate_frames.py
+++ b/examples/00_coordinate_frames.py
@@ -11,7 +11,7 @@ import time
 
 import viser
 
-server = viser.ViserServer()
+server = viser.ViserServer(share=True)
 
 while True:
     # Add some coordinate frames to the scene. These will be visualized in the viewer.

--- a/examples/08_smplx_visualizer.py
+++ b/examples/08_smplx_visualizer.py
@@ -35,7 +35,7 @@ def main(
     num_expression_coeffs: int = 10,
     ext: Literal["npz", "pkl"] = "npz",
 ) -> None:
-    server = viser.ViserServer()
+    server = viser.ViserServer(share=True)
     model = smplx.create(
         model_path=str(model_path),
         model_type=model_type,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "rich>=13.3.3",
     "trimesh>=3.21.7",
     "nodeenv>=1.8.0",
+    "rustenv>=0.0.6",
 ]
 
 [project.optional-dependencies]

--- a/viser/_tunnel.py
+++ b/viser/_tunnel.py
@@ -1,0 +1,61 @@
+"""Helper for creating shareable viser links using `bore`.
+
+https://github.com/ekzhang/bore
+"""
+
+import atexit
+import os
+import signal
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+BORE_SERVER = "chalupa.eecs.berkeley.edu"
+
+
+def start_tunnel(port: int) -> None:
+    env_dir = Path(__file__).absolute().parent / ".rustenv"
+    bore_path = env_dir / "rust" / "bin" / "bore"
+
+    if not env_dir.exists():
+        print("[viser] Tunneling: setting up Rust environment")
+        subprocess.run(args=[sys.executable, "-m", "rustenv", str(env_dir)])
+
+    if not bore_path.exists():
+        print("[viser] Tunneling: installing bore")
+        subprocess.run(args=[str(env_dir / "bin" / "cargo"), "install", "bore-cli"])
+
+    process = subprocess.Popen(
+        [f"{bore_path}", "local", str(port), "--to", BORE_SERVER],
+        stdout=subprocess.PIPE,
+    )
+
+    # Handle normal exists.
+    @atexit.register
+    def _():
+        process.terminate()
+        process.wait()
+
+    # Handle SIGTERM.
+    script_pid = os.getpid()
+
+    def handle_termination_signal(signum, frame):
+        process.kill()
+        os.kill(script_pid, signum)
+
+    signal.signal(signal.SIGTERM, handle_termination_signal)
+
+    def _bore_watcher() -> None:
+        while True:
+            assert process.stdout is not None
+            line = process.stdout.readline().decode().strip()
+            if "Error:" in line:
+                print(line)
+                break
+            if "listening at " in line:
+                print("[viser] Tunnel created at", line.partition("listening at ")[2])
+
+    threading.Thread(target=_bore_watcher).start()
+
+    return None

--- a/viser/_viser.py
+++ b/viser/_viser.py
@@ -232,7 +232,7 @@ class ViserServer(MessageApi, GuiApi):
 
     def __init__(self, host: str = "0.0.0.0", port: int = 8080, share: bool = False):
         if share:
-            print(start_tunnel(port, connection_timeout=10.0))
+            start_tunnel(port)
 
         server = infra.Server(
             host=host,

--- a/viser/_viser.py
+++ b/viser/_viser.py
@@ -16,6 +16,7 @@ from . import transforms as tf
 from ._gui_api import GuiApi
 from ._message_api import MessageApi, cast_vector
 from ._scene_handles import FrameHandle, _SceneNodeHandleState
+from ._tunnel import start_tunnel
 
 
 @dataclasses.dataclass
@@ -229,7 +230,10 @@ class ViserServer(MessageApi, GuiApi):
     """Handle for manipulating the world frame axes (/WorldAxes), which is instantiated
     and then hidden by default."""
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 8080):
+    def __init__(self, host: str = "0.0.0.0", port: int = 8080, share: bool = False):
+        if share:
+            print(start_tunnel(port, connection_timeout=10.0))
+
         server = infra.Server(
             host=host,
             port=port,


### PR DESCRIPTION
Here's a pass at automatically generating + printing a shareable link. It works for me — I can pass in `share=True` and it lets me connect to a `nerfstudio` viewer from a different machine/network.

The current implementation is similar to the `nodeenv` code that @origamiman72 wrote for client builds: it sets up a sandboxed Rust environment and builds + runs [bore](https://github.com/ekzhang/bore). `bore` seemed like the simplest of many options, some of which are surveyed here: https://github.com/anderspitman/awesome-tunneling

Some notes:
- TCP forwarding was pretty straightforward manually. Maybe we could just leave this out of the codebase, and point folks to resources for this.
- We do some manual parsing of `bore` log messages currently, which seems brittle.