### PR TITLE
Check to see if a Viewer is running and skip the build check

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "rich>=13.3.3",
     "trimesh>=3.21.7",
     "nodeenv>=1.8.0",
+    "psutil>=5.9.5",
 ]
 
 [project.optional-dependencies]

--- a/viser/_client_autobuild.py
+++ b/viser/_client_autobuild.py
@@ -1,9 +1,21 @@
 import subprocess
 import sys
+import psutil
+import rich
 from pathlib import Path
 
 client_dir = Path(__file__).absolute().parent / "client"
 build_dir = client_dir / "build"
+
+
+def _check_process(process_name: str) -> bool:
+    """
+    Check if a process is running
+    """
+    for process in psutil.process_iter():
+        if process_name == process.name():
+            return True
+    return False
 
 
 def ensure_client_is_built() -> None:
@@ -18,13 +30,20 @@ def ensure_client_is_built() -> None:
 
     # Do we need to re-trigger a build?
     build = False
+    if _check_process("Viser Viewer"):
+        rich.print(
+            "[bold](viser)[/bold] A Viser viewer is already running. Skipping build check..."
+        )
+        build = False
     if not (build_dir / "index.html").exists():
-        print("[viser] No client build found. Building now...")
+        rich.print("[bold](viser)[/bold] No client build found. Building now...")
         build = True
     elif _modified_time_recursive(client_dir / "src") > _modified_time_recursive(
         build_dir
     ):
-        print("[viser] Client build looks out of date. Building now...")
+        rich.print(
+            "[bold](viser)[/bold] Client build looks out of date. Building now..."
+        )
         build = True
 
     # Install nodejs and build if necessary. We assume bash is installed.
@@ -49,7 +68,7 @@ def _install_sandboxed_node() -> Path:
     environment root."""
     env_dir = client_dir / ".nodeenv"
     if (env_dir / "bin" / "npx").exists():
-        print("[viser] nodejs is set up!")
+        rich.print("[bold](viser)[/bold] nodejs is set up!")
         return env_dir
 
     subprocess.run([sys.executable, "-m", "nodeenv", "--node=20.4.0", env_dir])

--- a/viser/_client_autobuild.py
+++ b/viser/_client_autobuild.py
@@ -30,14 +30,14 @@ def ensure_client_is_built() -> None:
 
     # Do we need to re-trigger a build?
     build = False
-    if _check_process("Viser Viewer"):
+    if not (build_dir / "index.html").exists():
+        rich.print("[bold](viser)[/bold] No client build found. Building now...")
+        build = True
+    elif _check_process("Viser Viewer"):
         rich.print(
             "[bold](viser)[/bold] A Viser viewer is already running. Skipping build check..."
         )
         build = False
-    if not (build_dir / "index.html").exists():
-        rich.print("[bold](viser)[/bold] No client build found. Building now...")
-        build = True
     elif _modified_time_recursive(client_dir / "src") > _modified_time_recursive(
         build_dir
     ):

--- a/viser/client/vite.config.ts
+++ b/viser/client/vite.config.ts
@@ -5,6 +5,8 @@ import svgrPlugin from "vite-plugin-svgr";
 import eslint from "vite-plugin-eslint";
 import browserslistToEsbuild from "browserslist-to-esbuild";
 
+process.title = "Viser Viewer"
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react(), eslint(), viteTsconfigPaths(), svgrPlugin()],


### PR DESCRIPTION
This PR adds a line to the Vite config that sets the viewer's process name to "Viser Viewer", and adds a function that uses psutil to check if "Viser Viewer" exists in the process list. If it does and any build exists at all, it skips the build check.

This is mostly to speed up development, since it will stop the client from rebuilding every time an example is restarted while active changes are being made.