### PR TITLE
Fix Control Panel Bug with 3D GUIs

### DIFF
--- a/viser/client/src/ControlPanel/ControlPanel.tsx
+++ b/viser/client/src/ControlPanel/ControlPanel.tsx
@@ -40,8 +40,7 @@ export default function ControlPanel(props: {
 
   // TODO: will result in unnecessary re-renders
   const viewer = React.useContext(ViewerContext)!;
-  const showGenerated =
-    Object.keys(viewer.useGui((state) => state.guiConfigFromId)).length > 0;
+  const showGenerated = viewer.useGui((state) => 'root' in state.guiIdSetFromContainerId);
   const [showSettings, { toggle }] = useDisclosure(false);
   const [collapsed, { toggle: toggleCollapse }] = useDisclosure(false);
   const handleContents = (


### PR DESCRIPTION
In the current version, engaging with a 3D GUI when there is no GUI attached to the main Control Panel causes the Control Panel to break, since `showGenerated` checks for the presence of any GUI's, not for GUI's attached to `root`. As such, the Control Panel updates to feature a custom GUI that doesn't exist, causing the panel to break.

Resolution: Change `showGenerated` to check for root within `guiIdSetFromContainerId`.