### PR TITLE
Rework guiIdSetFromContainerId into a dict of sets

### DIFF
--- a/viser/client/src/ControlPanel/Generated.tsx
+++ b/viser/client/src/ControlPanel/Generated.tsx
@@ -36,7 +36,7 @@ export default function GeneratedGuiContainer({
   if (viewer === undefined) viewer = React.useContext(ViewerContext)!;
 
   const guiIdSet = viewer.useGui(
-    (state) => state.guiIdSetFromContainerId[containerId],
+    (state) => state.guiIdSetFromContainerId[containerId]
   );
   const guiConfigFromId = viewer.useGui((state) => state.guiConfigFromId);
 
@@ -44,7 +44,7 @@ export default function GeneratedGuiContainer({
   const out =
     guiIdSet === undefined ? null : (
       <Box pt="xs">
-        {[...Object.keys(guiIdSet)]
+        {[...guiIdSet]
           .map((id) => guiConfigFromId[id])
           .sort((a, b) => a.order - b.order)
           .map((conf, index) => {

--- a/viser/client/src/ControlPanel/GuiState.tsx
+++ b/viser/client/src/ControlPanel/GuiState.tsx
@@ -29,10 +29,8 @@ interface GuiState {
   server: string;
   websocketConnected: boolean;
   backgroundAvailable: boolean;
-  // We use an object whose values are always null to emulate a set.
-  // TODO: is there a less hacky way?
   guiIdSetFromContainerId: {
-    [containerId: string]: { [configId: string]: null } | undefined;
+    [containerId: string]: Set<string> | undefined;
   };
   guiConfigFromId: { [id: string]: GuiConfig };
   guiValueFromId: { [id: string]: any };
@@ -82,10 +80,9 @@ export function useGuiState(initialServer: string) {
         addGui: (guiConfig) =>
           set((state) => {
             state.guiConfigFromId[guiConfig.id] = guiConfig;
-            state.guiIdSetFromContainerId[guiConfig.container_id] = {
-              ...state.guiIdSetFromContainerId[guiConfig.container_id],
-              [guiConfig.id]: null,
-            };
+            state.guiIdSetFromContainerId[guiConfig.container_id] = new Set(
+              state.guiIdSetFromContainerId[guiConfig.container_id]
+            ).add(guiConfig.id);
           }),
         setGuiValue: (id, value) =>
           set((state) => {
@@ -113,9 +110,9 @@ export function useGuiState(initialServer: string) {
             if (guiConfig.type === "GuiAddTabGroupMessage")
               guiConfig.tab_container_ids.forEach(state.removeGuiContainer);
 
-            delete state.guiIdSetFromContainerId[guiConfig.container_id]![
+            state.guiIdSetFromContainerId[guiConfig.container_id]!.delete(
               guiConfig.id
-            ];
+            );
             delete state.guiConfigFromId[id];
             delete state.guiValueFromId[id];
             delete state.guiAttributeFromId[id];

--- a/viser/client/src/index.tsx
+++ b/viser/client/src/index.tsx
@@ -1,5 +1,8 @@
 import ReactDOM from "react-dom/client";
 import { Root } from "./App";
+import { enableMapSet } from "immer"
+
+enableMapSet();
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <Root />,


### PR DESCRIPTION
Does as the title suggests. Before we were relying on a generic object with `null` values.  This PR switches this out with a Javascript `Set<string>`, [introduced in ES6](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set).