### PR TITLE
Websocket refactor + theming

### DIFF
--- a/examples/08_smplx_visualizer.py
+++ b/examples/08_smplx_visualizer.py
@@ -36,6 +36,7 @@ def main(
     ext: Literal["npz", "pkl"] = "npz",
 ) -> None:
     server = viser.ViserServer()
+    server.configure_theme(control_layout="collapsible", dark_mode=True)
     model = smplx.create(
         model_path=str(model_path),
         model_type=model_type,

--- a/examples/13_theming.py
+++ b/examples/13_theming.py
@@ -1,6 +1,6 @@
 """Theming
 
-Viser is adding support for theming. Work-in-progress.
+Viser includes support for light theming.
 """
 
 import time
@@ -33,13 +33,14 @@ image = TitlebarImage(
     image_alt="NerfStudio Logo",
     href="https://docs.nerf.studio/",
 )
-
-# image = None
-
 titlebar_theme = TitlebarConfig(buttons=buttons, image=image)
 
+server.add_gui_markdown(
+    "Viser includes support for light theming via the `.configure_theme()` method."
+)
 
 # GUI elements for controllable values.
+titlebar = server.add_gui_checkbox("Titlebar", initial_value=True)
 dark_mode = server.add_gui_checkbox("Dark mode", initial_value=True)
 control_layout = server.add_gui_dropdown(
     "Control layout", ("floating", "fixed", "collapsible")
@@ -52,7 +53,7 @@ synchronize = server.add_gui_button("Apply theme")
 def synchronize_theme(_) -> None:
     server.configure_theme(
         dark_mode=dark_mode.value,
-        titlebar_content=titlebar_theme,
+        titlebar_content=titlebar_theme if titlebar.value else None,
         control_layout=control_layout.value,
         brand_color=brand_color.value,
     )

--- a/examples/13_theming.py
+++ b/examples/13_theming.py
@@ -38,10 +38,28 @@ image = TitlebarImage(
 
 titlebar_theme = TitlebarConfig(buttons=buttons, image=image)
 
-server.configure_theme(
-    dark_mode=True, titlebar_content=titlebar_theme, control_layout="fixed"
+
+# GUI elements for controllable values.
+dark_mode = server.add_gui_checkbox("Dark mode", initial_value=True)
+control_layout = server.add_gui_dropdown(
+    "Control layout", ("floating", "fixed", "collapsible")
 )
-server.world_axes.visible = True
+brand_color = server.add_gui_rgb("Brand color", (230, 180, 30))
+synchronize = server.add_gui_button("Apply theme")
+
+
+@synchronize.on_click
+def synchronize_theme(_) -> None:
+    server.configure_theme(
+        dark_mode=dark_mode.value,
+        titlebar_content=titlebar_theme,
+        control_layout=control_layout.value,
+        brand_color=brand_color.value,
+    )
+    server.world_axes.visible = True
+
+
+synchronize_theme(synchronize)
 
 while True:
     time.sleep(10.0)

--- a/examples/13_theming.py
+++ b/examples/13_theming.py
@@ -1,3 +1,6 @@
+# mypy: disable-error-code="arg-type"
+#
+# Waiting on PEP 675 support in mypy. https://github.com/python/mypy/issues/12554
 """Theming
 
 Viser includes support for light theming.

--- a/examples/16_modal.py
+++ b/examples/16_modal.py
@@ -14,7 +14,9 @@ def main():
     def _(client: viser.ClientHandle) -> None:
         with client.add_gui_modal("Modal example"):
             client.add_gui_markdown(
-                markdown="**The slider below determines how many modals will appear...**"
+                markdown=(
+                    "**The slider below determines how many modals will appear...**"
+                )
             )
 
             gui_slider = client.add_gui_slider(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ select = [
     "PLW",  # Pylint warnings.
 ]
 ignore = [
+    "E741", # Ambiguous variable name. (l, O, or I)
     "E501",  # Line too long.
     "F722",  # Forward annotation false positive from jaxtyping. Should be caught by pyright.
     "F821",  # Forward annotation false positive from jaxtyping. Should be caught by pyright.

--- a/viser/_message_api.py
+++ b/viser/_message_api.py
@@ -181,16 +181,13 @@ class MessageApi(abc.ABC):
                 max_l = min(0.8 + 0.5, 0.9)
                 l = max(min_l, min(max_l, l))
 
-                ls = []
                 primary_index = 8
                 ls = tuple(
                     onp.interp(
                         x=onp.arange(10), xp=(0, primary_index, 9), fp=(max_l, l, min_l)
                     )
                 )
-                colors_cast = tuple(_hex_from_hls(h, ls[i], s) for i in range(10))
-            else:
-                colors_cast = brand_color
+                colors_cast = tuple(_hex_from_hls(h, ls[i], s) for i in range(10))  # type: ignore
 
         assert colors_cast is None or all(
             [isinstance(val, str) and val.startswith("#") for val in colors_cast]

--- a/viser/_messages.py
+++ b/viser/_messages.py
@@ -451,4 +451,5 @@ class ThemeConfigurationMessage(Message):
 
     titlebar_content: Optional[theme.TitlebarConfig]
     control_layout: Literal["floating", "collapsible", "fixed"]
+    colors: Optional[Tuple[str, str, str, str, str, str, str, str, str, str]]
     dark_mode: bool

--- a/viser/client/src/ControlPanel/BottomPanel.tsx
+++ b/viser/client/src/ControlPanel/BottomPanel.tsx
@@ -1,7 +1,12 @@
 import { Box, Collapse, Paper } from "@mantine/core";
 import React from "react";
-import { FloatingPanelContext } from "./FloatingPanel";
 import { useDisclosure } from "@mantine/hooks";
+
+const BottomPanelContext = React.createContext<null | {
+  wrapperRef: React.RefObject<HTMLDivElement>;
+  expanded: boolean;
+  toggleExpanded: () => void;
+}>(null);
 
 export default function BottomPanel({
   children,
@@ -11,7 +16,7 @@ export default function BottomPanel({
   const panelWrapperRef = React.useRef<HTMLDivElement>(null);
   const [expanded, { toggle: toggleExpanded }] = useDisclosure(true);
   return (
-    <FloatingPanelContext.Provider
+    <BottomPanelContext.Provider
       value={{
         wrapperRef: panelWrapperRef,
         expanded: expanded,
@@ -38,7 +43,7 @@ export default function BottomPanel({
       >
         {children}
       </Paper>
-    </FloatingPanelContext.Provider>
+    </BottomPanelContext.Provider>
   );
 }
 BottomPanel.Handle = function BottomPanelHandle({
@@ -46,7 +51,7 @@ BottomPanel.Handle = function BottomPanelHandle({
 }: {
   children: string | React.ReactNode;
 }) {
-  const panelContext = React.useContext(FloatingPanelContext)!;
+  const panelContext = React.useContext(BottomPanelContext)!;
   return (
     <Box
       color="red"
@@ -55,24 +60,20 @@ BottomPanel.Handle = function BottomPanelHandle({
           theme.colorScheme == "dark"
             ? theme.colors.dark[5]
             : theme.colors.gray[1],
-        lineHeight: "2.5em",
         cursor: "pointer",
         position: "relative",
         fontWeight: 400,
         userSelect: "none",
+        display: "flex",
+        alignItems: "center",
+        padding: "0 0.8em",
+        height: "3.5em",
       })}
       onClick={() => {
         panelContext.toggleExpanded();
       }}
     >
-      <Box
-        component="div"
-        sx={{
-          padding: "0.5em 3em 0.5em 0.8em",
-        }}
-      >
-        {children}
-      </Box>
+      {children}
     </Box>
   );
 };
@@ -82,6 +83,6 @@ BottomPanel.Contents = function BottomPanelContents({
 }: {
   children: string | React.ReactNode;
 }) {
-  const panelContext = React.useContext(FloatingPanelContext)!;
+  const panelContext = React.useContext(BottomPanelContext)!;
   return <Collapse in={panelContext.expanded}>{children}</Collapse>;
 };

--- a/viser/client/src/ControlPanel/ControlPanel.tsx
+++ b/viser/client/src/ControlPanel/ControlPanel.tsx
@@ -38,18 +38,7 @@ export default function ControlPanel(props: {
   const [showSettings, { toggle }] = useDisclosure(false);
 
   const generatedServerToggleButton = (
-    <Box
-      sx={{
-        position: "absolute",
-        right: props.control_layout === "collapsible" ? "2.5em" : "0.5em",
-        top: "50%",
-        /* We can't apply translateY directly to the ActionIcon, since it's used by
-      Mantine for the active/click indicator. */
-        transform: "translateY(-50%)",
-        display: showGenerated ? undefined : "none",
-        zIndex: 100,
-      }}
-    >
+    <Box sx={{ display: showGenerated ? undefined : "none" }}>
       <ActionIcon
         onClick={(evt) => {
           evt.stopPropagation();
@@ -127,9 +116,7 @@ function ConnectionStatus() {
 
   const StatusIcon = connected ? IconCloudCheck : IconCloudOff;
   return (
-    <span
-      style={{ display: "flex", alignItems: "center", width: "max-content" }}
-    >
+    <>
       <StatusIcon
         color={connected ? "#0b0" : "#b00"}
         style={{
@@ -138,8 +125,9 @@ function ConnectionStatus() {
           height: "1.2em",
         }}
       />
-      &nbsp; &nbsp;
-      {label === "" ? server : label}
-    </span>
+      <Box px="xs" sx={{ flexGrow: 1 }}>
+        {label === "" ? server : label}
+      </Box>
+    </>
   );
 }

--- a/viser/client/src/ControlPanel/ControlPanel.tsx
+++ b/viser/client/src/ControlPanel/ControlPanel.tsx
@@ -1,10 +1,9 @@
 import { useDisclosure, useMediaQuery } from "@mantine/hooks";
 import GeneratedGuiContainer from "./Generated";
 import { ViewerContext } from "../App";
-import ServerControls from "./Server";
+import ServerControls from "./ServerControls";
 import {
   ActionIcon,
-  Aside,
   Box,
   Collapse,
   Tooltip,
@@ -160,12 +159,13 @@ export default function ControlPanel(props: {
         >
           {collapsedView}
         </Box>
-        <Aside
-          hiddenBreakpoint={"xs"}
-          fixed
+        {/* Using an <Aside /> below will break Mantine color inputs. */}
+        <Box
           sx={(theme) => ({
             width: collapsed ? 0 : "20em",
+            top: 0,
             bottom: 0,
+            right: 0,
             overflow: "scroll",
             boxSizing: "border-box",
             borderLeft: "1px solid",
@@ -174,6 +174,8 @@ export default function ControlPanel(props: {
                 ? theme.colors.gray[4]
                 : theme.colors.dark[4],
             transition: "width 0.5s 0s",
+            backgroundColor:
+              theme.colorScheme == "dark" ? theme.colors.dark[8] : "0xffffff",
           })}
         >
           <Box
@@ -198,7 +200,7 @@ export default function ControlPanel(props: {
             </Box>
             {panelContents}
           </Box>
-        </Aside>
+        </Box>
       </>
     );
   } else {

--- a/viser/client/src/ControlPanel/ControlPanel.tsx
+++ b/viser/client/src/ControlPanel/ControlPanel.tsx
@@ -14,22 +14,15 @@ import {
   IconCloudCheck,
   IconCloudOff,
   IconArrowBack,
-  IconChevronLeft,
-  IconChevronRight,
 } from "@tabler/icons-react";
 import React from "react";
 import BottomPanel from "./BottomPanel";
-import FloatingPanel, { FloatingPanelContext } from "./FloatingPanel";
+import FloatingPanel from "./FloatingPanel";
 import { ThemeConfigurationMessage } from "../WebsocketMessages";
+import SidebarPanel from "./SidebarPanel";
 
 // Must match constant in Python.
 const ROOT_CONTAINER_ID = "root";
-
-/** Hides contents when floating panel is collapsed. */
-function HideWhenCollapsed({ children }: { children: React.ReactNode }) {
-  const expanded = React.useContext(FloatingPanelContext)?.expanded ?? true;
-  return expanded ? children : null;
-}
 
 export default function ControlPanel(props: {
   control_layout: ThemeConfigurationMessage["control_layout"];
@@ -37,93 +30,43 @@ export default function ControlPanel(props: {
   const theme = useMantineTheme();
   const useMobileView = useMediaQuery(`(max-width: ${theme.breakpoints.xs})`);
 
-  // TODO: will result in unnecessary re-renders
+  // TODO: will result in unnecessary re-renders.
   const viewer = React.useContext(ViewerContext)!;
   const showGenerated = viewer.useGui(
     (state) => "root" in state.guiIdSetFromContainerId,
   );
   const [showSettings, { toggle }] = useDisclosure(false);
-  const [collapsed, { toggle: toggleCollapse }] = useDisclosure(false);
-  const handleContents = (
-    <>
-      <ConnectionStatus />
-      <HideWhenCollapsed>
-        {/* We can't apply translateY directly to the ActionIcon, since it's used by
-      Mantine for the active/click indicator. */}
-        <Box
-          sx={{
-            position: "absolute",
-            right: props.control_layout === "collapsible" ? "2.5em" : "0.5em",
-            top: "50%",
-            transform: "translateY(-50%)",
-            display: showGenerated ? undefined : "none",
-            zIndex: 100,
-          }}
-        >
-          <ActionIcon
-            onClick={(evt) => {
-              evt.stopPropagation();
-              toggle();
-            }}
-          >
-            <Tooltip
-              label={
-                showSettings ? "Return to GUI" : "Connection & diagnostics"
-              }
-            >
-              {showSettings ? <IconArrowBack /> : <IconAdjustments />}
-            </Tooltip>
-          </ActionIcon>
-        </Box>
-      </HideWhenCollapsed>
-      <Box
-        sx={{
-          position: "absolute",
-          right: "0.5em",
-          top: "50%",
-          transform: "translateY(-50%)",
-          display:
-            props.control_layout === "collapsible" && !useMobileView
-              ? undefined
-              : "none",
-          zIndex: 100,
-        }}
-      >
-        <ActionIcon
-          onClick={(evt) => {
-            evt.stopPropagation();
-            toggleCollapse();
-          }}
-        >
-          <Tooltip label={"Collapse Sidebar"}>{<IconChevronRight />}</Tooltip>
-        </ActionIcon>
-      </Box>
-    </>
-  );
 
-  const collapsedView = (
-    <div
-      style={{
-        borderTopLeftRadius: "15%",
-        borderBottomLeftRadius: "15%",
-        borderTopRightRadius: 0,
-        borderBottomRightRadius: 0,
-        backgroundColor:
-          theme.colorScheme == "dark"
-            ? theme.colors.dark[5]
-            : theme.colors.gray[2],
-        padding: "0.5em",
+  const generatedServerToggleButton = (
+    <Box
+      sx={{
+        position: "absolute",
+        right: props.control_layout === "collapsible" ? "2.5em" : "0.5em",
+        top: "50%",
+        /* We can't apply translateY directly to the ActionIcon, since it's used by
+      Mantine for the active/click indicator. */
+        transform: "translateY(-50%)",
+        display: showGenerated ? undefined : "none",
+        zIndex: 100,
       }}
     >
       <ActionIcon
         onClick={(evt) => {
           evt.stopPropagation();
-          toggleCollapse();
+          toggle();
         }}
       >
-        <Tooltip label={"Show Sidebar"}>{<IconChevronLeft />}</Tooltip>
+        <Tooltip
+          label={showSettings ? "Return to GUI" : "Connection & diagnostics"}
+        >
+          {showSettings ? (
+            <IconArrowBack stroke={1.625} />
+          ) : (
+            <IconAdjustments stroke={1.625} />
+          )}
+        </Tooltip>
       </ActionIcon>
-    </div>
+    </Box>
   );
 
   const panelContents = (
@@ -138,77 +81,39 @@ export default function ControlPanel(props: {
   );
 
   if (useMobileView) {
+    /* Mobile layout. */
     return (
       <BottomPanel>
-        <BottomPanel.Handle>{handleContents}</BottomPanel.Handle>
+        <BottomPanel.Handle>
+          <ConnectionStatus />
+          {generatedServerToggleButton}
+        </BottomPanel.Handle>
         <BottomPanel.Contents>{panelContents}</BottomPanel.Contents>
       </BottomPanel>
     );
-  } else if (props.control_layout !== "floating") {
-    return (
-      <>
-        <Box
-          sx={{
-            position: "absolute",
-            right: collapsed ? "0em" : "-2.5em",
-            top: "0.5em",
-            transitionProperty: "right",
-            transitionDuration: "0.5s",
-            transitionDelay: "0.25s",
-          }}
-        >
-          {collapsedView}
-        </Box>
-        {/* Using an <Aside /> below will break Mantine color inputs. */}
-        <Box
-          sx={(theme) => ({
-            width: collapsed ? 0 : "20em",
-            top: 0,
-            bottom: 0,
-            right: 0,
-            overflow: "scroll",
-            boxSizing: "border-box",
-            borderLeft: "1px solid",
-            borderColor:
-              theme.colorScheme == "light"
-                ? theme.colors.gray[4]
-                : theme.colors.dark[4],
-            transition: "width 0.5s 0s",
-            backgroundColor:
-              theme.colorScheme == "dark" ? theme.colors.dark[8] : "0xffffff",
-          })}
-        >
-          <Box
-            sx={() => ({
-              width: "20em",
-            })}
-          >
-            <Box
-              p="sm"
-              sx={(theme) => ({
-                backgroundColor:
-                  theme.colorScheme == "dark"
-                    ? theme.colors.dark[5]
-                    : theme.colors.gray[1],
-                lineHeight: "1.5em",
-                fontWeight: 400,
-                position: "relative",
-                zIndex: 1,
-              })}
-            >
-              {handleContents}
-            </Box>
-            {panelContents}
-          </Box>
-        </Box>
-      </>
-    );
-  } else {
+  } else if (props.control_layout === "floating") {
+    /* Floating layout. */
     return (
       <FloatingPanel>
-        <FloatingPanel.Handle>{handleContents}</FloatingPanel.Handle>
+        <FloatingPanel.Handle>
+          <ConnectionStatus />
+          <FloatingPanel.HideWhenCollapsed>
+            {generatedServerToggleButton}
+          </FloatingPanel.HideWhenCollapsed>
+        </FloatingPanel.Handle>
         <FloatingPanel.Contents>{panelContents}</FloatingPanel.Contents>
       </FloatingPanel>
+    );
+  } else {
+    /* Sidebar view. */
+    return (
+      <SidebarPanel collapsible={props.control_layout === "collapsible"}>
+        <SidebarPanel.Handle>
+          <ConnectionStatus />
+          {generatedServerToggleButton}
+        </SidebarPanel.Handle>
+        <SidebarPanel.Contents>{panelContents}</SidebarPanel.Contents>
+      </SidebarPanel>
     );
   }
 }

--- a/viser/client/src/ControlPanel/FloatingPanel.tsx
+++ b/viser/client/src/ControlPanel/FloatingPanel.tsx
@@ -39,7 +39,7 @@ export default function FloatingPanel({
           top: "1em",
           right: "1em",
           margin: 0,
-          overflowY: "auto",
+          overflowY: "scroll" /* overflowY: auto will break dropdown menus.*/,
           "& .expand-icon": {
             transform: "rotate(0)",
           },

--- a/viser/client/src/ControlPanel/FloatingPanel.tsx
+++ b/viser/client/src/ControlPanel/FloatingPanel.tsx
@@ -5,7 +5,7 @@ import React from "react";
 import { isMouseEvent, isTouchEvent, mouseEvents, touchEvents } from "../Utils";
 import { useDisclosure } from "@mantine/hooks";
 
-export const FloatingPanelContext = React.createContext<null | {
+const FloatingPanelContext = React.createContext<null | {
   wrapperRef: React.RefObject<HTMLDivElement>;
   expanded: boolean;
   toggleExpanded: () => void;
@@ -264,4 +264,14 @@ FloatingPanel.Contents = function FloatingPanelContents({
 }) {
   const context = React.useContext(FloatingPanelContext);
   return <Collapse in={context?.expanded ?? true}>{children}</Collapse>;
+};
+
+/** Hides contents when floating panel is collapsed. */
+FloatingPanel.HideWhenCollapsed = function FloatingPanelHideWhenCollapsed({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const expanded = React.useContext(FloatingPanelContext)?.expanded ?? true;
+  return expanded ? children : null;
 };

--- a/viser/client/src/ControlPanel/FloatingPanel.tsx
+++ b/viser/client/src/ControlPanel/FloatingPanel.tsx
@@ -30,11 +30,11 @@ export default function FloatingPanel({
     >
       <Paper
         radius="sm"
-        withBorder
+        shadow="lg"
         sx={{
           boxSizing: "border-box",
           width: "20em",
-          zIndex: 1,
+          zIndex: 300,
           position: "absolute",
           top: "1em",
           right: "1em",
@@ -229,6 +229,10 @@ FloatingPanel.Handle = function FloatingPanelHandle({
         position: "relative",
         fontWeight: 400,
         userSelect: "none",
+        display: "flex",
+        alignItems: "center",
+        padding: "0 0.8em",
+        height: "2.5em",
       })}
       onClick={() => {
         const state = dragInfo.current;
@@ -245,14 +249,7 @@ FloatingPanel.Handle = function FloatingPanelHandle({
         dragHandler(event);
       }}
     >
-      <Box
-        component="div"
-        sx={{
-          padding: "0.5em 2em 0.5em 0.8em",
-        }}
-      >
-        {children}
-      </Box>
+      {children}
     </Box>
   );
 };

--- a/viser/client/src/ControlPanel/Generated.tsx
+++ b/viser/client/src/ControlPanel/Generated.tsx
@@ -384,7 +384,9 @@ function GeneratedTabGroup({ conf }: { conf: GuiAddTabGroupMessage }) {
             icon={
               icons[index] === null ? undefined : (
                 <Image
-                  height="1.0rem"
+                  /*^In Safari, both the icon's height and width need to be set, otherwise the icon is clipped.*/
+                  height={"0.9rem"}
+                  width={"0.9rem"}
                   sx={(theme) => ({
                     filter:
                       theme.colorScheme == "dark" ? "invert(1)" : undefined,

--- a/viser/client/src/ControlPanel/Generated.tsx
+++ b/viser/client/src/ControlPanel/Generated.tsx
@@ -47,7 +47,7 @@ export default function GeneratedGuiContainer({
         {[...guiIdSet]
           .map((id) => guiConfigFromId[id])
           .sort((a, b) => a.order - b.order)
-          .map((conf, index) => {
+          .map((conf) => {
             return <GeneratedInput conf={conf} key={conf.id} viewer={viewer} />;
           })}
       </Box>
@@ -116,6 +116,7 @@ function GeneratedInput({
         <Button
           id={conf.id}
           fullWidth
+          color={"0x000"}
           onClick={() =>
             messageSender({
               type: "GuiUpdateMessage",

--- a/viser/client/src/ControlPanel/GuiState.tsx
+++ b/viser/client/src/ControlPanel/GuiState.tsx
@@ -59,6 +59,7 @@ const cleanGuiState: GuiState = {
     titlebar_content: null,
     control_layout: "floating",
     dark_mode: false,
+    colors: null,
   },
   label: "",
   server: "ws://localhost:8080", // Currently this will always be overridden.

--- a/viser/client/src/ControlPanel/ServerControls.tsx
+++ b/viser/client/src/ControlPanel/ServerControls.tsx
@@ -102,6 +102,7 @@ export default function ServerControls() {
           }}
         />
         <Divider my="sm" />
+        Scene tree
         <MemoizedTable compact={true} />
       </Stack>
     </>

--- a/viser/client/src/ControlPanel/SidebarPanel.tsx
+++ b/viser/client/src/ControlPanel/SidebarPanel.tsx
@@ -1,0 +1,149 @@
+// @refresh reset
+
+import { ActionIcon, Box, Tooltip } from "@mantine/core";
+import React from "react";
+import { useDisclosure } from "@mantine/hooks";
+import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
+
+export const SidebarPanelContext = React.createContext<null | {
+  collapsible: boolean;
+  toggleCollapsed: () => void;
+}>(null);
+
+/** Root component for control panel. Parents a set of control tabs.
+ * This could be refactored+cleaned up a lot! */
+export default function SidebarPanel({
+  children,
+  collapsible,
+}: {
+  children: string | React.ReactNode;
+  collapsible: boolean;
+}) {
+  const [collapsed, { toggle: toggleCollapsed }] = useDisclosure(false);
+
+  const collapsedView = (
+    <Box
+      sx={(theme) => ({
+        /* Animate in when collapsed. */
+        position: "absolute",
+        top: "0em",
+        right: collapsed ? "0em" : "-3em",
+        transitionProperty: "right",
+        transitionDuration: "0.5s",
+        transitionDelay: "0.25s",
+        /* Visuals. */
+        borderBottomLeftRadius: "0.5em",
+        backgroundColor:
+          theme.colorScheme == "dark"
+            ? theme.colors.dark[5]
+            : theme.colors.gray[2],
+        padding: "0.5em",
+      })}
+    >
+      <ActionIcon
+        onClick={(evt) => {
+          evt.stopPropagation();
+          toggleCollapsed();
+        }}
+      >
+        <Tooltip label={"Show sidebar"}>{<IconChevronLeft />}</Tooltip>
+      </ActionIcon>
+    </Box>
+  );
+
+  return (
+    <SidebarPanelContext.Provider
+      value={{
+        collapsible: collapsible,
+        toggleCollapsed: toggleCollapsed,
+      }}
+    >
+      {collapsedView}
+      {/* Using an <Aside /> below will break Mantine color inputs. */}
+      <Box
+        sx={(theme) => ({
+          width: collapsed ? 0 : "20em",
+          overflow: "scroll",
+          boxSizing: "border-box",
+          borderLeft: "1px solid",
+          borderColor:
+            theme.colorScheme == "light"
+              ? theme.colors.gray[4]
+              : theme.colors.dark[4],
+          transition: "width 0.5s 0s",
+          backgroundColor:
+            theme.colorScheme == "dark" ? theme.colors.dark[8] : "0xffffff",
+        })}
+      >
+        <Box
+          sx={{
+            width: "20em", // Prevent DOM reflow.
+          }}
+        >
+          {children}
+        </Box>
+      </Box>
+    </SidebarPanelContext.Provider>
+  );
+}
+
+/** Handle object helps us hide, show, and drag our panel.*/
+SidebarPanel.Handle = function SidebarPanelHandle({
+  children,
+}: {
+  children: string | React.ReactNode;
+}) {
+  const { toggleCollapsed, collapsible } =
+    React.useContext(SidebarPanelContext)!;
+
+  const collapseSidebarToggleButton = (
+    <Box
+      sx={{
+        position: "absolute",
+        right: "0.5em",
+        top: "50%",
+        transform: "translateY(-50%)",
+        display: collapsible ? undefined : "none",
+        zIndex: 100,
+      }}
+    >
+      <ActionIcon
+        onClick={(evt) => {
+          evt.stopPropagation();
+          toggleCollapsed();
+        }}
+      >
+        <Tooltip label={"Collapse sidebar"}>
+          {<IconChevronRight stroke={1.625} />}
+        </Tooltip>
+      </ActionIcon>
+    </Box>
+  );
+
+  return (
+    <Box
+      p="sm"
+      sx={(theme) => ({
+        backgroundColor:
+          theme.colorScheme == "dark"
+            ? theme.colors.dark[5]
+            : theme.colors.gray[1],
+        lineHeight: "1.5em",
+        fontWeight: 400,
+        position: "relative",
+        zIndex: 1,
+      })}
+    >
+      {children}
+      {collapseSidebarToggleButton}
+    </Box>
+  );
+};
+/** Contents of a panel. */
+SidebarPanel.Contents = function SidebarPanelContents({
+  children,
+}: {
+  children: string | React.ReactNode;
+}) {
+  return children;
+};

--- a/viser/client/src/ControlPanel/SidebarPanel.tsx
+++ b/viser/client/src/ControlPanel/SidebarPanel.tsx
@@ -1,6 +1,6 @@
 // @refresh reset
 
-import { ActionIcon, Box, Tooltip } from "@mantine/core";
+import { ActionIcon, Box, Paper, Tooltip } from "@mantine/core";
 import React from "react";
 import { useDisclosure } from "@mantine/hooks";
 import { IconChevronLeft, IconChevronRight } from "@tabler/icons-react";
@@ -60,20 +60,16 @@ export default function SidebarPanel({
     >
       {collapsedView}
       {/* Using an <Aside /> below will break Mantine color inputs. */}
-      <Box
-        sx={(theme) => ({
+      <Paper
+        shadow="lg"
+        radius={0}
+        sx={{
           width: collapsed ? 0 : "20em",
           overflow: "scroll",
           boxSizing: "border-box",
-          borderLeft: "1px solid",
-          borderColor:
-            theme.colorScheme == "light"
-              ? theme.colors.gray[4]
-              : theme.colors.dark[4],
           transition: "width 0.5s 0s",
-          backgroundColor:
-            theme.colorScheme == "dark" ? theme.colors.dark[8] : "0xffffff",
-        })}
+          zIndex: 300,
+        }}
       >
         <Box
           sx={{
@@ -82,7 +78,7 @@ export default function SidebarPanel({
         >
           {children}
         </Box>
-      </Box>
+      </Paper>
     </SidebarPanelContext.Provider>
   );
 }
@@ -97,32 +93,21 @@ SidebarPanel.Handle = function SidebarPanelHandle({
     React.useContext(SidebarPanelContext)!;
 
   const collapseSidebarToggleButton = (
-    <Box
-      sx={{
-        position: "absolute",
-        right: "0.5em",
-        top: "50%",
-        transform: "translateY(-50%)",
-        display: collapsible ? undefined : "none",
-        zIndex: 100,
+    <ActionIcon
+      onClick={(evt) => {
+        evt.stopPropagation();
+        toggleCollapsed();
       }}
     >
-      <ActionIcon
-        onClick={(evt) => {
-          evt.stopPropagation();
-          toggleCollapsed();
-        }}
-      >
-        <Tooltip label={"Collapse sidebar"}>
-          {<IconChevronRight stroke={1.625} />}
-        </Tooltip>
-      </ActionIcon>
-    </Box>
+      <Tooltip label={"Collapse sidebar"}>
+        {<IconChevronRight stroke={1.625} />}
+      </Tooltip>
+    </ActionIcon>
   );
 
   return (
     <Box
-      p="sm"
+      p="xs"
       sx={(theme) => ({
         backgroundColor:
           theme.colorScheme == "dark"
@@ -132,10 +117,13 @@ SidebarPanel.Handle = function SidebarPanelHandle({
         fontWeight: 400,
         position: "relative",
         zIndex: 1,
+        alignItems: "center",
+        display: "flex",
+        flexDirection: "row",
       })}
     >
       {children}
-      {collapseSidebarToggleButton}
+      {collapsible ? collapseSidebarToggleButton : null}
     </Box>
   );
 };

--- a/viser/client/src/Titlebar.tsx
+++ b/viser/client/src/Titlebar.tsx
@@ -65,7 +65,7 @@ export function TitlebarButton(
       ml="sm"
       color="gray"
       sx={(theme) => ({
-        [theme.fn.smallerThan("sm")]: {
+        [theme.fn.smallerThan("xs")]: {
           display: "none",
         },
       })}
@@ -138,72 +138,69 @@ export function Titlebar() {
 
   return (
     <Header
-      p="xs"
       height="3.2em"
-      sx={(theme) => ({
+      sx={{
         margin: 0,
-        borderBottom: "1px solid",
-        borderColor:
-          theme.colorScheme == "light"
-            ? theme.colors.gray[4]
-            : theme.colors.dark[4],
-        zIndex: 299,
-      })}
+        border: "0",
+        zIndex: 200,
+      }}
     >
-      <Container
-        fluid
-        sx={() => ({
-          display: "flex",
-          alignItems: "center",
-        })}
-      >
-        <Group sx={() => ({ marginRight: "auto" })}>
-          {imageData !== null ? TitlebarImage(imageData, theme) : null}
-        </Group>
-        <Group
+      <Paper p="xs" shadow="md" sx={{ height: "100%" }}>
+        <Container
+          fluid
           sx={() => ({
-            flexWrap: "nowrap",
-            overflowX: "scroll",
-            msOverflowStyle: "none",
-            scrollbarWidth: "none",
-            "&::-webkit-scrollbar": {
-              display: "none",
-            },
+            display: "flex",
+            alignItems: "center",
           })}
         >
-          {buttons?.map((btn) => TitlebarButton(btn))}
-        </Group>
-        <Burger
-          size="sm"
-          opened={burgerOpen}
-          onClick={burgerHandlers.toggle}
-          title={!burgerOpen ? "Open navigation" : "Close navigation"}
+          <Group sx={() => ({ marginRight: "auto" })}>
+            {imageData !== null ? TitlebarImage(imageData, theme) : null}
+          </Group>
+          <Group
+            sx={() => ({
+              flexWrap: "nowrap",
+              overflowX: "scroll",
+              msOverflowStyle: "none",
+              scrollbarWidth: "none",
+              "&::-webkit-scrollbar": {
+                display: "none",
+              },
+            })}
+          >
+            {buttons?.map((btn) => TitlebarButton(btn))}
+          </Group>
+          <Burger
+            size="sm"
+            opened={burgerOpen}
+            onClick={burgerHandlers.toggle}
+            title={!burgerOpen ? "Open navigation" : "Close navigation"}
+            sx={(theme) => ({
+              [theme.fn.largerThan("xs")]: {
+                display: "none",
+              },
+            })}
+          ></Burger>
+        </Container>
+        <Paper
           sx={(theme) => ({
-            [theme.fn.largerThan("sm")]: {
+            [theme.fn.largerThan("xs")]: {
               display: "none",
             },
+            display: "flex",
+            flexDirection: "column",
+            position: "relative",
+            top: 0,
+            left: "-0.625rem",
+            zIndex: 10000000,
+            height: burgerOpen ? "calc(100vh - 2.375em)" : "0",
+            width: "100vw",
+            transition: "all 0.5s",
+            overflow: burgerOpen ? "scroll" : "hidden",
+            padding: burgerOpen ? "1rem" : "0",
           })}
-        ></Burger>
-      </Container>
-      <Paper
-        sx={(theme) => ({
-          [theme.fn.largerThan("sm")]: {
-            display: "none",
-          },
-          display: "flex",
-          flexDirection: "column",
-          position: "relative",
-          top: 0,
-          left: "-0.625rem",
-          zIndex: 10000000,
-          height: burgerOpen ? "calc(100vh - 2.375em)" : "0",
-          width: "100vw",
-          transition: "all 0.5s",
-          overflow: burgerOpen ? "scroll" : "hidden",
-          padding: burgerOpen ? "1rem" : "0",
-        })}
-      >
-        {buttons?.map((btn) => MobileTitlebarButton(btn))}
+        >
+          {buttons?.map((btn) => MobileTitlebarButton(btn))}
+        </Paper>
       </Paper>
     </Header>
   );

--- a/viser/client/src/WebsocketInterface.tsx
+++ b/viser/client/src/WebsocketInterface.tsx
@@ -473,7 +473,7 @@ function useMessageHandler() {
                       width: "20em",
                       fontSize: "0.8em",
                     }}
-                    withBorder
+                    shadow="md"
                   >
                     <GeneratedGuiContainer
                       containerId={message.container_id}

--- a/viser/client/src/WebsocketMessages.tsx
+++ b/viser/client/src/WebsocketMessages.tsx
@@ -342,6 +342,20 @@ export interface ThemeConfigurationMessage {
     } | null;
   } | null;
   control_layout: "floating" | "collapsible" | "fixed";
+  colors:
+    | [
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+        string,
+      ]
+    | null;
   dark_mode: boolean;
 }
 


### PR DESCRIPTION
Here's a pass at #80!

The changes are:
- Broke down the `<WebsocketInterface />` component to disentangle the websocket message "producer" and the message handling "consumer". This is cleaner, helps prevent the re-render loops described in #80, and will also make some other tasks/projects easier (like the non-websocket sources of messages that @AdamRashid96 and I have been prototyping).
- Cleaned up the control panel code to break it down more cleanly into bottom, side, and floating panel components. The old logic got tangled very quickly.
- Replace a lot of absolute positioning with flexbox, which feels much simpler. When the collapsible side panel is expanded, we now also shrink the viewport, which should help with NeRF rendering times.
- Added a `brand_color` argument to `.configure_theme()`, which takes a single RGB tuple as input.
- Various aesthetic tweaks, theme color configuration, example updates. Here's the updated theming example:

https://github.com/nerfstudio-project/viser/assets/6992947/0df08e25-e1fd-4470-8e34-fb1594655f15
