### PR TITLE
Expose GUI ordering API

### DIFF
--- a/examples/02_gui.py
+++ b/examples/02_gui.py
@@ -39,7 +39,6 @@ def main():
             "Size",
             initial_value=(1.0, 1.0, 1.0),
             step=0.25,
-            lock=True,
         )
         with server.add_gui_folder("Text toggle"):
             gui_checkbox_hide = server.add_gui_checkbox(

--- a/viser/_gui_handles.py
+++ b/viser/_gui_handles.py
@@ -113,6 +113,11 @@ class _GuiInputHandle(Generic[T]):
     # Is this worth the tradeoff?
 
     @property
+    def order(self) -> float:
+        """Read-only order value, which dictates the position of the GUI element."""
+        return self._impl.order
+
+    @property
     def value(self) -> T:
         """Value of the GUI input. Synchronized automatically when assigned."""
         return self._impl.value
@@ -321,6 +326,12 @@ class GuiTabGroupHandle:
     _tabs: List[GuiTabHandle]
     _gui_api: GuiApi
     _container_id: str  # Parent.
+    _order: float
+
+    @property
+    def order(self) -> float:
+        """Read-only order value, which dictates the position of the GUI element."""
+        return self.order
 
     def add_tab(self, label: str, icon: Optional[Icon] = None) -> GuiTabHandle:
         """Add a tab. Returns a handle we can use to add GUI elements to it."""
@@ -346,8 +357,8 @@ class GuiTabGroupHandle:
     def _sync_with_client(self) -> None:
         """Send a message that syncs tab state with the client."""
         self._gui_api._get_api()._queue(
-            GuiAddTabGroupMessage(
-                order=time.time(),
+            GuiAddTabGroupM_ordere(
+                order=self.order,
                 id=self._tab_group_id,
                 container_id=self._container_id,
                 tab_labels=tuple(self._labels),
@@ -363,11 +374,17 @@ class GuiFolderHandle:
 
     _gui_api: GuiApi
     _id: str  # Used as container ID for children.
+    _order: float
     _parent_container_id: str  # Container ID of parent.
     _container_id_restore: Optional[str] = None
     _children: Dict[str, SupportsRemoveProtocol] = dataclasses.field(
         default_factory=dict
     )
+
+    @property
+    def order(self) -> float:
+        """Read-only order value, which dictates the position of the GUI element."""
+        return self.order
 
     def __enter__(self) -> GuiFolderHandle:
         self._container_id_restore = self._gui_api._get_container_id()
@@ -484,6 +501,12 @@ class GuiMarkdownHandle:
     _id: str
     _visible: bool
     _container_id: str  # Parent.
+    _order: float
+
+    @property
+    def order(self) -> float:
+        """Read-only order value, which dictates the position of the GUI element."""
+        return self.order
 
     @property
     def visible(self) -> bool:

--- a/viser/_gui_handles.py
+++ b/viser/_gui_handles.py
@@ -357,7 +357,7 @@ class GuiTabGroupHandle:
     def _sync_with_client(self) -> None:
         """Send a message that syncs tab state with the client."""
         self._gui_api._get_api()._queue(
-            GuiAddTabGroupM_ordere(
+            GuiAddTabGroupMessage(
                 order=self.order,
                 id=self._tab_group_id,
                 container_id=self._container_id,


### PR DESCRIPTION
1. We move away from setting `order` base on `time.time()`, which I imagine would fail in Windows. In Windows, `time.time()` uses 16ms increments; we've replaced this with a global counter.

2. We expose the `.order` property for GUI handles and the `order=` argument for "add GUI" methods. These will make it easier to, as an example, add a new GUI element between two existing ones or in place of an existing one.