### PR TITLE
Check mouse drag using onPointerDown/Move/Up

### DIFF
--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -13,7 +13,7 @@ export function SynchronizedCameraControls() {
 
   const sendCameraThrottled = makeThrottledMessageSender(
     viewer.websocketRef,
-    20
+    20,
   );
 
   // Helper for resetting camera poses.
@@ -30,12 +30,12 @@ export function SynchronizedCameraControls() {
       initialCameraRef.current!.lookAt.x,
       initialCameraRef.current!.lookAt.y,
       initialCameraRef.current!.lookAt.z,
-      true
+      true,
     );
     viewer.cameraRef.current!.up.set(
       initialCameraRef.current!.camera.up.x,
       initialCameraRef.current!.camera.up.y,
-      initialCameraRef.current!.camera.up.z
+      initialCameraRef.current!.camera.up.z,
     );
     viewer.cameraControlRef.current!.updateCameraUp();
   };
@@ -161,28 +161,28 @@ export function SynchronizedCameraControls() {
       cameraControls.rotate(
         -0.05 * THREE.MathUtils.DEG2RAD * event?.deltaTime,
         0,
-        true
+        true,
       );
     });
     rightKey.addEventListener("holding", (event) => {
       cameraControls.rotate(
         0.05 * THREE.MathUtils.DEG2RAD * event?.deltaTime,
         0,
-        true
+        true,
       );
     });
     upKey.addEventListener("holding", (event) => {
       cameraControls.rotate(
         0,
         -0.05 * THREE.MathUtils.DEG2RAD * event?.deltaTime,
-        true
+        true,
       );
     });
     downKey.addEventListener("holding", (event) => {
       cameraControls.rotate(
         0,
         0.05 * THREE.MathUtils.DEG2RAD * event?.deltaTime,
-        true
+        true,
       );
     });
 

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -12,7 +12,7 @@ import { Text } from "@mantine/core";
 import { useSceneTreeState } from "./SceneTreeState";
 
 export type MakeObject<T extends THREE.Object3D = THREE.Object3D> = (
-  ref: React.Ref<T>
+  ref: React.Ref<T>,
 ) => React.ReactNode;
 
 /** Scenes will consist of nodes, which form a tree. */
@@ -25,7 +25,7 @@ export class SceneNode<T extends THREE.Object3D = THREE.Object3D> {
   constructor(
     public name: string,
     public makeObject: MakeObject<T>,
-    public cleanup?: () => void
+    public cleanup?: () => void,
   ) {
     this.children = [];
     this.clickable = false;
@@ -41,7 +41,7 @@ function SceneNodeThreeChildren(props: {
 }) {
   const viewer = React.useContext(ViewerContext)!;
   const children = viewer.useSceneTree(
-    (state) => state.nodeFromName[props.name]?.children
+    (state) => state.nodeFromName[props.name]?.children,
   );
 
   // Create a group of children inside of the parent object.
@@ -53,7 +53,7 @@ function SceneNodeThreeChildren(props: {
         })}
       <SceneNodeLabel name={props.name} />
     </group>,
-    props.parent
+    props.parent,
   );
 }
 
@@ -61,7 +61,7 @@ function SceneNodeThreeChildren(props: {
 function SceneNodeLabel(props: { name: string }) {
   const viewer = React.useContext(ViewerContext)!;
   const labelVisible = viewer.useSceneTree(
-    (state) => state.labelVisibleFromName[props.name]
+    (state) => state.labelVisibleFromName[props.name],
   );
   return labelVisible ? (
     <Html>
@@ -84,10 +84,10 @@ function SceneNodeLabel(props: { name: string }) {
 export function SceneNodeThreeObject(props: { name: string }) {
   const viewer = React.useContext(ViewerContext)!;
   const makeObject = viewer.useSceneTree(
-    (state) => state.nodeFromName[props.name]?.makeObject
+    (state) => state.nodeFromName[props.name]?.makeObject,
   );
   const cleanup = viewer.useSceneTree(
-    (state) => state.nodeFromName[props.name]?.cleanup
+    (state) => state.nodeFromName[props.name]?.cleanup,
   );
   const clickable =
     viewer.useSceneTree((state) => state.nodeFromName[props.name]?.clickable) ??
@@ -101,7 +101,7 @@ export function SceneNodeThreeObject(props: { name: string }) {
   // PivotControls.
   const objNode = React.useMemo(
     () => makeObject && makeObject(setRef),
-    [makeObject]
+    [makeObject],
   );
   const children =
     obj === null ? null : (
@@ -146,7 +146,7 @@ export function SceneNodeThreeObject(props: { name: string }) {
   // Clicking logic.
   const sendClicksThrottled = makeThrottledMessageSender(
     viewer.websocketRef,
-    50
+    50,
   );
   const [hovered, setHovered] = React.useState(false);
   const [dragged, setDragged] = React.useState(false);

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -12,7 +12,7 @@ import { Text } from "@mantine/core";
 import { useSceneTreeState } from "./SceneTreeState";
 
 export type MakeObject<T extends THREE.Object3D = THREE.Object3D> = (
-  ref: React.Ref<T>,
+  ref: React.Ref<T>
 ) => React.ReactNode;
 
 /** Scenes will consist of nodes, which form a tree. */
@@ -25,7 +25,7 @@ export class SceneNode<T extends THREE.Object3D = THREE.Object3D> {
   constructor(
     public name: string,
     public makeObject: MakeObject<T>,
-    public cleanup?: () => void,
+    public cleanup?: () => void
   ) {
     this.children = [];
     this.clickable = false;
@@ -41,7 +41,7 @@ function SceneNodeThreeChildren(props: {
 }) {
   const viewer = React.useContext(ViewerContext)!;
   const children = viewer.useSceneTree(
-    (state) => state.nodeFromName[props.name]?.children,
+    (state) => state.nodeFromName[props.name]?.children
   );
 
   // Create a group of children inside of the parent object.
@@ -53,7 +53,7 @@ function SceneNodeThreeChildren(props: {
         })}
       <SceneNodeLabel name={props.name} />
     </group>,
-    props.parent,
+    props.parent
   );
 }
 
@@ -61,7 +61,7 @@ function SceneNodeThreeChildren(props: {
 function SceneNodeLabel(props: { name: string }) {
   const viewer = React.useContext(ViewerContext)!;
   const labelVisible = viewer.useSceneTree(
-    (state) => state.labelVisibleFromName[props.name],
+    (state) => state.labelVisibleFromName[props.name]
   );
   return labelVisible ? (
     <Html>
@@ -84,10 +84,10 @@ function SceneNodeLabel(props: { name: string }) {
 export function SceneNodeThreeObject(props: { name: string }) {
   const viewer = React.useContext(ViewerContext)!;
   const makeObject = viewer.useSceneTree(
-    (state) => state.nodeFromName[props.name]?.makeObject,
+    (state) => state.nodeFromName[props.name]?.makeObject
   );
   const cleanup = viewer.useSceneTree(
-    (state) => state.nodeFromName[props.name]?.cleanup,
+    (state) => state.nodeFromName[props.name]?.cleanup
   );
   const clickable =
     viewer.useSceneTree((state) => state.nodeFromName[props.name]?.clickable) ??
@@ -101,7 +101,7 @@ export function SceneNodeThreeObject(props: { name: string }) {
   // PivotControls.
   const objNode = React.useMemo(
     () => makeObject && makeObject(setRef),
-    [makeObject],
+    [makeObject]
   );
   const children =
     obj === null ? null : (
@@ -146,7 +146,7 @@ export function SceneNodeThreeObject(props: { name: string }) {
   // Clicking logic.
   const sendClicksThrottled = makeThrottledMessageSender(
     viewer.websocketRef,
-    50,
+    50
   );
   const [hovered, setHovered] = React.useState(false);
   const [dragged, setDragged] = React.useState(false);
@@ -171,55 +171,34 @@ export function SceneNodeThreeObject(props: { name: string }) {
           //  - onPointerMove, if triggered, sets dragged = true
           //  - onPointerUp, if triggered, sends a click if dragged = false.
           // Note: It would be cool to have dragged actions too...
-          onPointerDown={
-            !clickable
-              ? undefined
-              : (e) => {
-                  if (!isVisible()) return;
-                  e.stopPropagation();
-                  setDragged(false);
-                }
-          }
-          onPointerMove={
-            !clickable
-              ? undefined
-              : (e) => {
-                  if (!isVisible()) return;
-                  e.stopPropagation();
-                  if (dragged) return;
-                  setDragged(true);
-                }
-          }
-          onPointerUp={
-            !clickable
-              ? undefined
-              : (e) => {
-                  if (!isVisible()) return;
-                  e.stopPropagation();
-                  if (dragged) return;
-                  sendClicksThrottled({
-                    type: "SceneNodeClickedMessage",
-                    name: props.name,
-                  });
-                }
-          }
-          onPointerOver={
-            !clickable
-              ? undefined
-              : (e) => {
-                  if (!isVisible()) return;
-                  e.stopPropagation();
-                  setHovered(true);
-                }
-          }
-          onPointerOut={
-            !clickable
-              ? undefined
-              : () => {
-                  if (!isVisible()) return;
-                  setHovered(false);
-                }
-          }
+          onPointerDown={(e) => {
+            if (!isVisible()) return;
+            e.stopPropagation();
+            setDragged(false);
+          }}
+          onPointerMove={(e) => {
+            if (!isVisible()) return;
+            e.stopPropagation();
+            setDragged(true);
+          }}
+          onPointerUp={(e) => {
+            if (!isVisible()) return;
+            e.stopPropagation();
+            if (dragged) return;
+            sendClicksThrottled({
+              type: "SceneNodeClickedMessage",
+              name: props.name,
+            });
+          }}
+          onPointerOver={(e) => {
+            if (!isVisible()) return;
+            e.stopPropagation();
+            setHovered(true);
+          }}
+          onPointerOut={() => {
+            if (!isVisible()) return;
+            setHovered(false);
+          }}
         >
           <Select enabled={hovered}>{objNode}</Select>
         </group>

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -149,6 +149,7 @@ export function SceneNodeThreeObject(props: { name: string }) {
     50,
   );
   const [hovered, setHovered] = React.useState(false);
+  const [dragged, setDragged] = React.useState(false);
   useCursor(hovered);
   if (!clickable && hovered) setHovered(false);
 
@@ -164,12 +165,38 @@ export function SceneNodeThreeObject(props: { name: string }) {
     return (
       <>
         <group
-          onClick={
+          // Instead of using onClick, we use onPointerDown/Move/Up to check mouse drag,
+          // and only send a click if the mouse hasn't moved between the down and up events.
+          //  - onPointerDown resets the click state (dragged = false)
+          //  - onPointerMove, if triggered, sets dragged = true
+          //  - onPointerUp, if triggered, sends a click if dragged = false.
+          // Note: It would be cool to have dragged actions too...
+          onPointerDown={
             !clickable
               ? undefined
               : (e) => {
                   if (!isVisible()) return;
                   e.stopPropagation();
+                  setDragged(false);
+                }
+          }
+          onPointerMove={
+            !clickable
+              ? undefined
+              : (e) => {
+                  if (!isVisible()) return;
+                  e.stopPropagation();
+                  if (dragged) return;
+                  setDragged(true);
+                }
+          }
+          onPointerUp={
+            !clickable
+              ? undefined
+              : (e) => {
+                  if (!isVisible()) return;
+                  e.stopPropagation();
+                  if (dragged) return;
                   sendClicksThrottled({
                     type: "SceneNodeClickedMessage",
                     name: props.name,


### PR DESCRIPTION
Use onPointerDown/Move/Up to detect drag, instead of onClick.

Clicks should only be registered if:
 - onPointerDown originates inside a clickable object
 - onPointerMove is never registered between the pointer down+up
 - onPointerUp originates within the same object