### PR TITLE
Account for minimum motion for node clicks

### DIFF
--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -113,6 +113,12 @@ export function SceneNodeThreeObject(props: {
     false;
   const [obj, setRef] = React.useState<THREE.Object3D | null>(null);
 
+  const dragInfo = React.useRef({
+    dragging: false,
+    startClientX: 0,
+    startClientY: 0,
+  });
+
   // Create object + children.
   //
   // For not-fully-understood reasons, wrapping makeObject with useMemo() fixes
@@ -219,11 +225,20 @@ export function SceneNodeThreeObject(props: {
           onPointerDown={(e) => {
             if (!isDisplayed()) return;
             e.stopPropagation();
+            const state = dragInfo.current;
+            state.startClientX = e.clientX;
+            state.startClientY = e.clientY;
             setDragged(false);
           }}
           onPointerMove={(e) => {
             if (!isDisplayed()) return;
             e.stopPropagation();
+            const state = dragInfo.current;
+            const deltaX = e.clientX - state.startClientX;
+            const deltaY = e.clientY - state.startClientY;
+            // Minimum motion.
+            console.log(deltaX, deltaY);
+            if (Math.abs(deltaX) <= 3 && Math.abs(deltaY) <= 3) return;
             setDragged(true);
           }}
           onPointerUp={(e) => {

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -206,7 +206,6 @@ export function SceneNodeThreeObject(props: {
     50
   );
   const [hovered, setHovered] = React.useState(false);
-  const [dragged, setDragged] = React.useState(false);
   useCursor(hovered);
   if (!clickable && hovered) setHovered(false);
 
@@ -228,7 +227,7 @@ export function SceneNodeThreeObject(props: {
             const state = dragInfo.current;
             state.startClientX = e.clientX;
             state.startClientY = e.clientY;
-            setDragged(false);
+            state.dragging = false;
           }}
           onPointerMove={(e) => {
             if (!isDisplayed()) return;
@@ -239,12 +238,13 @@ export function SceneNodeThreeObject(props: {
             // Minimum motion.
             console.log(deltaX, deltaY);
             if (Math.abs(deltaX) <= 3 && Math.abs(deltaY) <= 3) return;
-            setDragged(true);
+            state.dragging = true;
           }}
           onPointerUp={(e) => {
             if (!isDisplayed()) return;
             e.stopPropagation();
-            if (dragged) return;
+            const state = dragInfo.current;
+            if (state.dragging) return;
             sendClicksThrottled({
               type: "SceneNodeClickedMessage",
               name: props.name,


### PR DESCRIPTION
The previous drag-detection for scene node clicks would give no leeway (if onPointerMove detected then automatically disables the click). This should fix it. :~) 