### PR TITLE
Add assignable `.content` property to markdown handles

### DIFF
--- a/examples/14_markdown.py
+++ b/examples/14_markdown.py
@@ -11,24 +11,32 @@ import viser
 server = viser.ViserServer()
 server.world_axes.visible = True
 
+markdown_counter = server.add_gui_markdown("Counter: 0")
 
-@server.on_client_connect
-def _(client: viser.ClientHandle) -> None:
-    here = Path(__file__).absolute().parent
-    markdown_source = (here / "./assets/mdx_example.mdx").read_text()
-    markdown = client.add_gui_markdown(markdown=markdown_source, image_root=here)
+here = Path(__file__).absolute().parent
 
-    button = client.add_gui_button("Remove Markdown")
-    checkbox = client.add_gui_checkbox("Visibility", initial_value=True)
+button = server.add_gui_button("Remove blurb")
+checkbox = server.add_gui_checkbox("Visibility", initial_value=True)
 
-    @button.on_click
-    def _(_):
-        markdown.remove()
-
-    @checkbox.on_update
-    def _(_):
-        markdown.visible = checkbox.value
+markdown_source = (here / "./assets/mdx_example.mdx").read_text()
+markdown_blurb = server.add_gui_markdown(
+    content=markdown_source,
+    image_root=here,
+)
 
 
+@button.on_click
+def _(_):
+    markdown_blurb.remove()
+
+
+@checkbox.on_update
+def _(_):
+    markdown_blurb.visible = checkbox.value
+
+
+counter = 0
 while True:
-    time.sleep(10.0)
+    markdown_counter.content = f"Counter: {counter}"
+    counter += 1
+    time.sleep(0.1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ warn_unused_configs = true
 exclude="viser/client/.nodeenv"
 
 [tool.pyright]
-exclude = ["./docs/**/*", "./examples/assets/**/*", "./viser/client/.nodeenv", "./build"]
+exclude = ["./docs/**/*", "./examples/assets/**/*", "./src/viser/client/.nodeenv", "./build"]
 
 [tool.black]
 exclude = "viser/client/.nodeenv"

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -6,6 +6,7 @@ import threading
 import time
 import urllib.parse
 import uuid
+import warnings
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,

--- a/src/viser/client/src/Markdown.tsx
+++ b/src/viser/client/src/Markdown.tsx
@@ -177,7 +177,7 @@ export default function Markdown(props: { children?: string }) {
     } catch {
       setChild(<Title order={2}>Error Parsing Markdown...</Title>);
     }
-  }, []);
+  }, [props.children]);
 
   return child;
 }


### PR DESCRIPTION
We can now update the content of a markdown element.

I added a counter to the example:

https://github.com/nerfstudio-project/viser/assets/6992947/3b56a391-e93b-4852-bb76-81e1302c61ba

