### PR TITLE
JPG arg fix in imageio

### DIFF
--- a/src/viser/_message_api.py
+++ b/src/viser/_message_api.py
@@ -113,7 +113,7 @@ def _encode_image_base64(
                 data_buffer,
                 image[..., :3],  # Strip alpha.
                 extension=".jpeg",
-                jpeg_quality=75 if jpeg_quality is None else jpeg_quality,
+                quality=75 if jpeg_quality is None else jpeg_quality,
             )
         else:
             assert_never(format)


### PR DESCRIPTION
jpg quality was being ignored, the correct arg is `quality=`, not `jpeg_quality=`