### PR TITLE
Reverse up-down viewport navigation for Q and E keys

### DIFF
--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -147,10 +147,10 @@ export function SynchronizedCameraControls() {
       cameraControls.forward(-0.002 * event?.deltaTime, true);
     });
     qKey.addEventListener("holding", (event) => {
-      cameraControls.elevate(0.002 * event?.deltaTime, true);
+      cameraControls.elevate(-0.002 * event?.deltaTime, true);
     });
     eKey.addEventListener("holding", (event) => {
-      cameraControls.elevate(-0.002 * event?.deltaTime, true);
+      cameraControls.elevate(0.002 * event?.deltaTime, true);
     });
 
     const leftKey = new holdEvent.KeyboardKeyHold(KEYCODE.ARROW_LEFT, 20);


### PR DESCRIPTION
Reversing the up-down viewport camera translation navigation so that Q makes the camera go down and E makes the camera to go up (earlier they were swapped). This is to match the original Nerfstudio viewer (and also similar to Unity).

Regarding the up-down arrow keys for panning rotating up and down, I noticed that they are reversed compared to the original Nerfstudio viewer, however the current direction of movement for the up down arrow keys in Viser is more ideal for viewing meshes. I am wondering if there is a way to only customize the key input for the new Nerfstudio viewer without affecting Viser for only the up down arrow keys.