### PR TITLE
Add Google Analytics to viser docs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,3 +4,4 @@ docutils==0.20.1
 m2r2==0.3.3.post2
 git+https://github.com/brentyi/sphinxcontrib-programoutput.git
 git+https://github.com/brentyi/ansi.git
+git+https://github.com/sphinx-contrib/googleanalytics.git

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -181,7 +181,13 @@ latex_elements: Dict[str, str] = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "viser.tex", "viser", "brentyi", "manual",),
+    (
+        master_doc,
+        "viser.tex",
+        "viser",
+        "brentyi",
+        "manual",
+    ),
 ]
 
 
@@ -198,7 +204,15 @@ man_pages = [(master_doc, "viser", "viser documentation", [author], 1)]
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, "viser", "viser", author, "viser", "viser", "Miscellaneous",),
+    (
+        master_doc,
+        "viser",
+        "viser",
+        author,
+        "viser",
+        "viser",
+        "Miscellaneous",
+    ),
 ]
 
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,7 @@ extensions = [
     "m2r2",
     "sphinxcontrib.programoutput",
     "sphinxcontrib.ansi",
+    "sphinxcontrib.googleanalytics", # google analytics extension https://github.com/sphinx-contrib/googleanalytics/tree/master
 ]
 programoutput_use_ansi = True
 html_ansi_stylesheet = "black-on-white.css"
@@ -216,6 +217,9 @@ texinfo_documents = [
 
 
 # -- Extension configuration --------------------------------------------------
+
+# Google Analytics ID
+googleanalytics_id = 'G-RRGY51J5ZH'
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,7 +50,7 @@ extensions = [
     "m2r2",
     "sphinxcontrib.programoutput",
     "sphinxcontrib.ansi",
-    "sphinxcontrib.googleanalytics", # google analytics extension https://github.com/sphinx-contrib/googleanalytics/tree/master
+    "sphinxcontrib.googleanalytics",  # google analytics extension https://github.com/sphinx-contrib/googleanalytics/tree/master
 ]
 programoutput_use_ansi = True
 html_ansi_stylesheet = "black-on-white.css"
@@ -181,13 +181,7 @@ latex_elements: Dict[str, str] = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (
-        master_doc,
-        "viser.tex",
-        "viser",
-        "brentyi",
-        "manual",
-    ),
+    (master_doc, "viser.tex", "viser", "brentyi", "manual",),
 ]
 
 
@@ -204,22 +198,14 @@ man_pages = [(master_doc, "viser", "viser documentation", [author], 1)]
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (
-        master_doc,
-        "viser",
-        "viser",
-        author,
-        "viser",
-        "viser",
-        "Miscellaneous",
-    ),
+    (master_doc, "viser", "viser", author, "viser", "viser", "Miscellaneous",),
 ]
 
 
 # -- Extension configuration --------------------------------------------------
 
 # Google Analytics ID
-googleanalytics_id = 'G-RRGY51J5ZH'
+googleanalytics_id = "G-RRGY51J5ZH"
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ dev = [
     "pyright>=1.1.308",
     "mypy>=1.4.1",
     "ruff==0.0.267",
-    "black==23.3.0",
+    "black==23.11.0",
     "pre-commit==3.3.2",
 ]
 examples = [


### PR DESCRIPTION
- To do this I used this Sphinx extension for google analytics
https://github.com/sphinx-contrib/googleanalytics/tree/master
- Set up viser docs in GA dashboard under property name "viser docs"

