### PR TITLE
Add Google Analytics to viser

### DIFF
--- a/src/viser/client/index.html
+++ b/src/viser/client/index.html
@@ -1,6 +1,15 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-662WDGHPZZ"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'G-662WDGHPZZ');
+    </script>
     <meta charset="utf-8" />
     <link rel="icon" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
Set up google analytics for viser. Correspondingly named "viser" in GA dashboard. 

GA will still track despite the app being hosted locally.
