### PR TITLE
New share URL API

### DIFF
--- a/examples/07_record3d_visualizer.py
+++ b/examples/07_record3d_visualizer.py
@@ -22,7 +22,9 @@ def main(
     max_frames: int = 100,
     share: bool = False,
 ) -> None:
-    server = viser.ViserServer(share=share)
+    server = viser.ViserServer()
+    if share:
+        server.request_share_url()
 
     print("Loading frames!")
     loader = viser.extras.Record3dLoader(data_path)

--- a/examples/08_smplx_visualizer.py
+++ b/examples/08_smplx_visualizer.py
@@ -36,7 +36,10 @@ def main(
     ext: Literal["npz", "pkl"] = "npz",
     share: bool = False,
 ) -> None:
-    server = viser.ViserServer(share=share)
+    server = viser.ViserServer()
+    if share:
+        server.get_share_url()
+
     server.configure_theme(control_layout="collapsible")
     model = smplx.create(
         model_path=str(model_path),

--- a/examples/08_smplx_visualizer.py
+++ b/examples/08_smplx_visualizer.py
@@ -38,7 +38,7 @@ def main(
 ) -> None:
     server = viser.ViserServer()
     if share:
-        server.get_share_url()
+        server.request_share_url()
 
     server.configure_theme(control_layout="collapsible")
     model = smplx.create(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "viser"
-version = "0.1.12"
+version = "0.1.13"
 description = "3D visualization + Python"
 readme = "README.md"
 license = { text="MIT" }

--- a/src/viser/_tunnel.py
+++ b/src/viser/_tunnel.py
@@ -3,7 +3,7 @@ import multiprocessing as mp
 import threading
 import time
 from multiprocessing.managers import DictProxy
-from typing import Callable, Optional
+from typing import Callable, Literal, Optional
 
 import requests
 
@@ -45,6 +45,11 @@ class _ViserTunnel:
     def get_url(self) -> Optional[str]:
         """Get tunnel URL. None if not connected (or connection failed)."""
         return self._shared_state["url"]
+
+    def get_status(
+        self,
+    ) -> Literal["ready", "connecting", "failed", "connected", "closed"]:
+        return self._shared_state["status"]
 
     def close(self) -> None:
         """Close the tunnel."""
@@ -103,6 +108,9 @@ async def _make_tunnel(local_port: int, shared_state: DictProxy) -> None:
             for _ in range(res["max_conn_count"])
         ]
     )
+
+    shared_state["url"] = None
+    shared_state["status"] = "closed"
 
 
 async def _simple_proxy(

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -426,7 +426,7 @@ class ViserServer(MessageApi, GuiApi):
         # This is deprecated: we should use get_share_url() instead.
         share = _deprecated_kwargs.get("share", False)
         if share:
-            self.get_share_url()
+            self.request_share_url()
 
         self.reset_scene()
         self.world_axes = FrameHandle(
@@ -456,7 +456,7 @@ class ViserServer(MessageApi, GuiApi):
         """
         return self._server._port
 
-    def get_share_url(self, verbose: bool = True) -> Optional[str]:
+    def request_share_url(self, verbose: bool = True) -> Optional[str]:
         """Request a share URL for the Viser server, which allows for public access.
         On the first call, will block until a connecting with the share URL server is
         established. Afterwards, the URL will be returned directly.

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -593,4 +593,4 @@ class ViserServer(MessageApi, GuiApi):
         self._server.broadcast(message)
 
 
-ViserServer.__init__ = ViserServer._actual_init
+ViserServer.__init__ = ViserServer._actual_init  # type: ignore

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -420,7 +420,7 @@ class ViserServer(MessageApi, GuiApi):
         table.add_row("Websocket", ws_url)
         rich.print(Panel(table, title="[bold]viser[/bold]", expand=False))
 
-        self._share_tunnel = None
+        self._share_tunnel: Optional[_ViserTunnel] = None
 
         # Create share tunnel if requested.
         # This is deprecated: we should use get_share_url() instead.
@@ -479,9 +479,10 @@ class ViserServer(MessageApi, GuiApi):
                 rich.print(
                     "[bold](viser)[/bold] Share URL requested! (expires in 24 hours)"
                 )
-            self._share_tunnel = _ViserTunnel(self._server._port)
 
             connect_event = threading.Event()
+
+            self._share_tunnel = _ViserTunnel(self._server._port)
 
             @self._share_tunnel.on_connect
             def _() -> None:

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -302,15 +302,19 @@ class ViserServer(MessageApi, GuiApi):
     Args:
         host: Host to bind server to.
         port: Port to bind server to.
-        share: Experimental. If set to `True`, create and print a public, shareable URL
-            for this instance of viser.
     """
 
     world_axes: FrameHandle
     """Handle for manipulating the world frame axes (/WorldAxes), which is instantiated
     and then hidden by default."""
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 8080, share: bool = False):
+    # Hide deprecated arguments from docstring and type checkers.
+    def __init__(self, host: str = "0.0.0.0", port: int = 8080):
+        ...
+
+    def _actual_init(
+        self, host: str = "0.0.0.0", port: int = 8080, **_deprecated_kwargs
+    ):
         server = infra.Server(
             host=host,
             port=port,
@@ -414,26 +418,15 @@ class ViserServer(MessageApi, GuiApi):
         )
         table.add_row("HTTP", http_url)
         table.add_row("Websocket", ws_url)
+        rich.print(Panel(table, title="[bold]viser[/bold]", expand=False))
+
+        self._share_tunnel = None
 
         # Create share tunnel if requested.
-        if not share:
-            self._share_tunnel = None
-            rich.print(Panel(table, title="[bold]viser[/bold]", expand=False))
-        else:
-            rich.print(
-                "[bold](viser)[/bold] Share URL requested! (expires in 24 hours)"
-            )
-            self._share_tunnel = _ViserTunnel(port)
-
-            @self._share_tunnel.on_connect
-            def _() -> None:
-                assert self._share_tunnel is not None
-                share_url = self._share_tunnel.get_url()
-                if share_url is None:
-                    rich.print("[bold](viser)[/bold] Could not generate share URL")
-                else:
-                    table.add_row("Share URL", share_url)
-                rich.print(Panel(table, title="[bold]viser[/bold]", expand=False))
+        # This is deprecated: we should use get_share_url() instead.
+        share = _deprecated_kwargs.get("share", False)
+        if share:
+            self.get_share_url()
 
         self.reset_scene()
         self.world_axes = FrameHandle(
@@ -463,9 +456,13 @@ class ViserServer(MessageApi, GuiApi):
         """
         return self._server._port
 
-    def get_share_url(self) -> Optional[str]:
-        """Returns a share URL for the Viser server. If one does not exist, a new one
-        will be requested and the function will block until it is ready.
+    def get_share_url(self, verbose: bool = True) -> Optional[str]:
+        """Request a share URL for the Viser server, which allows for public access.
+        On the first call, will block until a connecting with the share URL server is
+        established. Afterwards, the URL will be returned directly.
+
+        This is an experimental feature that relies on an external server; it shouldn't
+        be relied on for critical applications.
 
         Returns:
             Share URL as string, or None if connection fails or is closed.
@@ -478,9 +475,10 @@ class ViserServer(MessageApi, GuiApi):
             return self._share_tunnel.get_url()
         else:
             # Create a new tunnel!.
-            rich.print(
-                "[bold](viser)[/bold] Share URL requested! (expires in 24 hours)"
-            )
+            if verbose:
+                rich.print(
+                    "[bold](viser)[/bold] Share URL requested! (expires in 24 hours)"
+                )
             self._share_tunnel = _ViserTunnel(self._server._port)
 
             connect_event = threading.Event()
@@ -488,11 +486,14 @@ class ViserServer(MessageApi, GuiApi):
             @self._share_tunnel.on_connect
             def _() -> None:
                 assert self._share_tunnel is not None
-                share_url = self._share_tunnel.get_url()
-                if share_url is None:
-                    rich.print("[bold](viser)[/bold] Could not generate share URL")
-                else:
-                    rich.print(f"[bold](viser)[/bold] Generated share URL: {share_url}")
+                if verbose:
+                    share_url = self._share_tunnel.get_url()
+                    if share_url is None:
+                        rich.print("[bold](viser)[/bold] Could not generate share URL")
+                    else:
+                        rich.print(
+                            f"[bold](viser)[/bold] Generated share URL: {share_url}"
+                        )
                 connect_event.set()
 
             connect_event.wait()
@@ -589,3 +590,6 @@ class ViserServer(MessageApi, GuiApi):
     def _queue_unsafe(self, message: _messages.Message) -> None:
         """Define how the message API should send messages."""
         self._server.broadcast(message)
+
+
+ViserServer.__init__ = ViserServer._actual_init


### PR DESCRIPTION
- Deprecated `ViserServer(share=True)`. This syntax will still work indefinitely, but will disappear from docs + fail type checks.
- Instead, we can call `server.request_share_url()` to request a share URL. It returns a string if successful.
- Also added access methods for the server's host and port.