### PR TITLE
Fix float/int type edge cases

### DIFF
--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -130,7 +130,17 @@ class GuiApi(abc.ABC):
             return
 
         handle_state = handle._impl
-        value = handle_state.typ(message.value)
+
+        # Do some type casting. This is necessary when we expect floats but the
+        # Javascript side gives us integers.
+        if handle_state.typ is tuple:
+            assert len(message.value) == len(handle_state.value)
+            value = tuple(
+                type(handle_state.value[i])(message.value[i])
+                for i in range(len(message.value))
+            )
+        else:
+            value = handle_state.typ(message.value)
 
         # Only call update when value has actually changed.
         if not handle_state.is_button and value == handle_state.value:

--- a/src/viser/infra/_messages.py
+++ b/src/viser/infra/_messages.py
@@ -48,7 +48,9 @@ def _prepare_for_serialization(value: Any, annotation: Type) -> Any:
                 out.append(
                     # Hack to be OK with wrong type annotations.
                     # https://github.com/nerfstudio-project/nerfstudio/pull/1805
-                    _prepare_for_serialization(v, args[i]) if i < len(args) else v
+                    _prepare_for_serialization(v, args[i])
+                    if i < len(args)
+                    else v
                 )
             return tuple(out)
 


### PR DESCRIPTION
When we're serializing things from Javascript `0.0` is the same as `0` and `1.0` is the same as `1` (they're all `number`), so we end up with some situations in Python where we expect floats but get integers.