### PR TITLE
GUI rendering optimizations

### DIFF
--- a/src/viser/client/src/ControlPanel/Generated.tsx
+++ b/src/viser/client/src/ControlPanel/Generated.tsx
@@ -506,7 +506,7 @@ function GeneratedFolder({
   const guiIdSet = viewer.useGui(
     (state) => state.guiIdSetFromContainerId[conf.id],
   );
-  const isEmpty = guiIdSet === undefined || guiIdSet.size === 0;
+  const isEmpty = guiIdSet === undefined || Object.keys(guiIdSet).length === 0;
 
   const ToggleIcon = opened ? IconChevronUp : IconChevronDown;
   return (

--- a/src/viser/client/src/ControlPanel/GuiState.tsx
+++ b/src/viser/client/src/ControlPanel/GuiState.tsx
@@ -34,9 +34,10 @@ interface GuiState {
   websocketConnected: boolean;
   backgroundAvailable: boolean;
   guiIdSetFromContainerId: {
-    [containerId: string]: Set<string> | undefined;
+    [containerId: string]: { [id: string]: true } | undefined;
   };
   modals: Messages.GuiModalMessage[];
+  guiOrderFromId: { [id: string]: number };
   guiConfigFromId: { [id: string]: GuiConfig };
   guiValueFromId: { [id: string]: any };
   guiAttributeFromId: {
@@ -72,6 +73,7 @@ const cleanGuiState: GuiState = {
   backgroundAvailable: false,
   guiIdSetFromContainerId: {},
   modals: [],
+  guiOrderFromId: {},
   guiConfigFromId: {},
   guiValueFromId: {},
   guiAttributeFromId: {},
@@ -101,10 +103,14 @@ export function useGuiState(initialServer: string) {
           }),
         addGui: (guiConfig) =>
           set((state) => {
+            state.guiOrderFromId[guiConfig.id] = guiConfig.order;
             state.guiConfigFromId[guiConfig.id] = guiConfig;
-            state.guiIdSetFromContainerId[guiConfig.container_id] = new Set(
-              state.guiIdSetFromContainerId[guiConfig.container_id],
-            ).add(guiConfig.id);
+            if (!(guiConfig.container_id in state.guiIdSetFromContainerId)) {
+              state.guiIdSetFromContainerId[guiConfig.container_id] = {};
+            }
+            state.guiIdSetFromContainerId[guiConfig.container_id]![
+              guiConfig.id
+            ] = true;
           }),
         addModal: (modalConfig) =>
           set((state) => {
@@ -136,9 +142,8 @@ export function useGuiState(initialServer: string) {
           set((state) => {
             const guiConfig = state.guiConfigFromId[id];
 
-            state.guiIdSetFromContainerId[guiConfig.container_id]!.delete(
-              guiConfig.id,
-            );
+            delete state.guiIdSetFromContainerId[guiConfig.container_id]![id];
+            delete state.guiOrderFromId[id];
             delete state.guiConfigFromId[id];
             delete state.guiValueFromId[id];
             delete state.guiAttributeFromId[id];
@@ -146,6 +151,7 @@ export function useGuiState(initialServer: string) {
         resetGui: () =>
           set((state) => {
             state.guiIdSetFromContainerId = {};
+            state.guiOrderFromId = {};
             state.guiConfigFromId = {};
             state.guiValueFromId = {};
             state.guiAttributeFromId = {};


### PR DESCRIPTION
Previously if we had a GUI container with 100 elements, all of them would be re-rendered if the "config" struct for one of them changed. 

As an example: this happens when we update the content of a markdown element.

I did some React optimizations; now only the updated element should re-render.