### PR TITLE
Improved point cloud shader

### DIFF
--- a/examples/07_record3d_visualizer.py
+++ b/examples/07_record3d_visualizer.py
@@ -105,6 +105,7 @@ def main(
             points=position,
             colors=color,
             point_size=0.01,
+            point_shape="rounded",
         )
 
         # Place the frustum.

--- a/src/viser/_message_api.py
+++ b/src/viser/_message_api.py
@@ -661,6 +661,9 @@ class MessageApi(abc.ABC):
         points: onp.ndarray,
         colors: onp.ndarray | Tuple[float, float, float],
         point_size: float = 0.1,
+        point_shape: Literal[
+            "square", "diamond", "circle", "rounded", "sparkle"
+        ] = "square",
         wxyz: Tuple[float, float, float, float] | onp.ndarray = (1.0, 0.0, 0.0, 0.0),
         position: Tuple[float, float, float] | onp.ndarray = (0.0, 0.0, 0.0),
         visible: bool = True,
@@ -672,6 +675,7 @@ class MessageApi(abc.ABC):
             points: Location of points. Should have shape (N, 3).
             colors: Colors of points. Should have shape (N, 3) or (3,).
             point_size: Size of each point.
+            point_shape: Shape to draw each point.
             wxyz: Quaternion rotation to parent frame from local frame (R_pl).
             position: Translation to parent frame from local frame (t_pl).
             visible: Whether or not this scene node is initially visible.
@@ -697,6 +701,13 @@ class MessageApi(abc.ABC):
                 points=points.astype(onp.float32),
                 colors=colors_cast,
                 point_size=point_size,
+                point_ball_norm={
+                    "square": 0.0,
+                    "diamond": 1.0,
+                    "circle": 2.0,
+                    "rounded": 3.0,
+                    "sparkle": 0.6,
+                }[point_shape],
             )
         )
         return PointCloudHandle._make(self, name, wxyz, position, visible)

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -158,7 +158,8 @@ class PointCloudMessage(Message):
     name: str
     points: onpt.NDArray[onp.float32]
     colors: onpt.NDArray[onp.uint8]
-    point_size: float = 0.1
+    point_size: float
+    point_ball_norm: float
 
     def __post_init__(self):
         # Check shapes.

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -24,7 +24,6 @@ import {
   LineDashedMaterial,
 } from "three";
 import { DRACOLoader } from "three/examples/jsm/loaders/DRACOLoader";
-import { ViewerContext } from "./App";
 
 type AllPossibleThreeJSMaterials =
   | MeshBasicMaterial

--- a/src/viser/client/src/WebsocketInterface.tsx
+++ b/src/viser/client/src/WebsocketInterface.tsx
@@ -15,6 +15,7 @@ import {
   CoordinateFrame,
   GlbAsset,
   OutlinesIfHovered,
+  PointCloud,
 } from "./ThreeAssets";
 import {
   FileDownloadPart,
@@ -195,52 +196,25 @@ function useMessageHandler() {
 
       // Add a point cloud.
       case "PointCloudMessage": {
-        const geometry = new THREE.BufferGeometry();
-        const pointCloudMaterial = new THREE.PointsMaterial({
-          size: message.point_size,
-          vertexColors: true,
-          toneMapped: false,
-        });
-
-        // Reinterpret cast: uint8 buffer => float32 for positions.
-        geometry.setAttribute(
-          "position",
-          new THREE.Float32BufferAttribute(
-            new Float32Array(
-              message.points.buffer.slice(
-                message.points.byteOffset,
-                message.points.byteOffset + message.points.byteLength,
-              ),
-            ),
-            3,
-          ),
-        );
-        geometry.computeBoundingSphere();
-
-        // Wrap uint8 buffer for colors. Note that we need to set normalized=true.
-        geometry.setAttribute(
-          "color",
-          threeColorBufferFromUint8Buffer(message.colors),
-        );
-
         addSceneNodeMakeParents(
-          new SceneNode<THREE.Points>(
-            message.name,
-            (ref) => (
-              <points
-                ref={ref}
-                geometry={geometry}
-                material={pointCloudMaterial}
-              />
-            ),
-            () => {
-              // TODO: we can switch to the react-three-fiber <bufferGeometry />,
-              // <pointsMaterial />, etc components to avoid manual
-              // disposal.
-              geometry.dispose();
-              pointCloudMaterial.dispose();
-            },
-          ),
+          new SceneNode<THREE.Points>(message.name, (ref) => (
+            <PointCloud
+              ref={ref}
+              pointSize={message.point_size}
+              pointBallNorm={message.point_ball_norm}
+              points={
+                new Float32Array(
+                  message.points.buffer.slice(
+                    message.points.byteOffset,
+                    message.points.byteOffset + message.points.byteLength,
+                  ),
+                )
+              }
+              colors={new Float32Array(message.colors).map(
+                (val) => val / 255.0,
+              )}
+            />
+          )),
         );
         return;
       }

--- a/src/viser/client/src/WebsocketMessages.tsx
+++ b/src/viser/client/src/WebsocketMessages.tsx
@@ -128,6 +128,7 @@ export interface PointCloudMessage {
   points: Uint8Array;
   colors: Uint8Array;
   point_size: number;
+  point_ball_norm: number;
 }
 /** Mesh message.
  *


### PR DESCRIPTION
Point cloud rendering now:
- Correctly takes the camera intrinsics into account. This puts `point_size` in the same units as everything else in `viser`. Points in the previous `PointsMaterial` implementation were always the same size regardless of FOV.
- Supports rendering points of different shapes. A square for each point is still the default; we also added support for rounding the corners, circles, etc.

`point_shape="rounded"`:
![image](https://github.com/nerfstudio-project/viser/assets/6992947/c038b15a-aa29-40f3-905f-ceb17cdbc459)
