### PR TITLE
Tone mapping fixes

### DIFF
--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -378,6 +378,7 @@ export const CameraFrustum = React.forwardRef<
             transparent={true}
             side={THREE.DoubleSide}
             map={props.image}
+            toneMapped={false}
           />
         </mesh>
       )}

--- a/src/viser/client/src/WebsocketInterface.tsx
+++ b/src/viser/client/src/WebsocketInterface.tsx
@@ -519,8 +519,6 @@ function useMessageHandler() {
         new TextureLoader().load(
           `data:${message.media_type};base64,${message.base64_rgb}`,
           (texture) => {
-            texture.encoding = THREE.sRGBEncoding;
-
             const oldBackgroundTexture =
               viewer.backgroundMaterialRef.current!.uniforms.colorMap.value;
             viewer.backgroundMaterialRef.current!.uniforms.colorMap.value =


### PR DESCRIPTION
This was broken by #156.

Test image:
![image](https://github.com/nerfstudio-project/viser/assets/6992947/b7a56421-fb07-4015-bca3-d01e11c2b33b)

Before:
![image](https://github.com/nerfstudio-project/viser/assets/6992947/bbfb34ca-1c23-413f-ac56-36fe4fc8bb7c)

After:
![image](https://github.com/nerfstudio-project/viser/assets/6992947/a68790f1-7726-4709-a141-cf19f581e25b)
