### PR TITLE
Implement `.add_frames_batched()`

### DIFF
--- a/docs/source/scene_handles.md
+++ b/docs/source/scene_handles.md
@@ -16,6 +16,8 @@ connected clients. When a scene node is added to a client (for example, via
 
 .. autoclass:: viser.FrameHandle
 
+.. autoclass:: viser.FramesBatchedHandle
+
 .. autoclass:: viser.GlbHandle
 
 .. autoclass:: viser.Gui3dContainerHandle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "viser"
-version = "0.1.21"
+version = "0.1.22"
 description = "3D visualization + Python"
 readme = "README.md"
 license = { text="MIT" }

--- a/src/viser/_message_api.py
+++ b/src/viser/_message_api.py
@@ -582,8 +582,8 @@ class MessageApi(abc.ABC):
     def add_frames_batched(
         self,
         name: str,
-        instance_wxyzs: onp.ndarray,
-        instance_positions: onp.ndarray,
+        wxyzs_batched: Tuple[Tuple[float, float, float, float], ...] | onp.ndarray,
+        positions_batched: Tuple[Tuple[float, float, float], ...] | onp.ndarray,
         axes_length: float = 0.5,
         axes_radius: float = 0.025,
         wxyz: Tuple[float, float, float, float] | onp.ndarray = (1.0, 0.0, 0.0, 0.0),
@@ -599,8 +599,8 @@ class MessageApi(abc.ABC):
         Args:
             name: A scene tree name. Names in the format of /parent/child can be used to
                 define a kinematic tree.
-            instanced_wxyzs: Float array of shape (N,4).
-            instanced_positions: Float array of shape (N,3).
+            wxyzs_batched: Float array of shape (N,4).
+            positions_batched: Float array of shape (N,3).
             axes_length: Length of each axis.
             axes_radius: Radius of each axis.
             wxyz: Quaternion rotation to parent frame from local frame (R_pl).
@@ -610,14 +610,17 @@ class MessageApi(abc.ABC):
         Returns:
             Handle for manipulating scene node.
         """
-        num_frames = instance_wxyzs.shape[0]
-        assert instance_wxyzs.shape == (num_frames, 4)
-        assert instance_positions.shape == (num_frames, 3)
+        wxyzs_batched = onp.asarray(wxyzs_batched)
+        positions_batched = onp.asarray(positions_batched)
+
+        num_frames = wxyzs_batched.shape[0]
+        assert wxyzs_batched.shape == (num_frames, 4)
+        assert positions_batched.shape == (num_frames, 3)
         self._queue(
             _messages.FrameBatchedMessage(
                 name=name,
-                instance_wxyzs=instance_wxyzs.astype(onp.float32),
-                instance_positions=instance_positions.astype(onp.float32),
+                wxyzs_batched=wxyzs_batched.astype(onp.float32),
+                positions_batched=positions_batched.astype(onp.float32),
                 axes_length=axes_length,
                 axes_radius=axes_radius,
             )

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -115,8 +115,8 @@ class FrameBatchedMessage(Message):
     corresponds to the R matrix and t vector in `p_parent = [R | t] p_local`."""
 
     name: str
-    instance_wxyzs: onpt.NDArray[onp.float32]
-    instance_positions: onpt.NDArray[onp.float32]
+    wxyzs_batched: onpt.NDArray[onp.float32]
+    positions_batched: onpt.NDArray[onp.float32]
     axes_length: float
     axes_radius: float
 

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -108,6 +108,20 @@ class FrameMessage(Message):
 
 
 @dataclasses.dataclass
+class FrameBatchedMessage(Message):
+    """Batched coordinate frames message.
+
+    Position and orientation should follow a `T_parent_local` convention, which
+    corresponds to the R matrix and t vector in `p_parent = [R | t] p_local`."""
+
+    name: str
+    instance_wxyzs: onpt.NDArray[onp.float32]
+    instance_positions: onpt.NDArray[onp.float32]
+    axes_length: float
+    axes_radius: float
+
+
+@dataclasses.dataclass
 class GridMessage(Message):
     """Grid message. Helpful for visualizing things like ground planes."""
 

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -187,6 +187,11 @@ class PointCloudHandle(SceneNodeHandle):
 
 
 @dataclasses.dataclass
+class FramesBatchedHandle(SceneNodeHandle):
+    """Handle for batched coordinate frames."""
+
+
+@dataclasses.dataclass
 class FrameHandle(_ClickableSceneNodeHandle):
     """Handle for coordinate frames."""
 

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -241,12 +241,16 @@ export const GlbAsset = React.forwardRef<
 export const CoordinateFrame = React.forwardRef<
   THREE.Group,
   {
-    show_axes?: boolean;
-    axes_length?: number;
-    axes_radius?: number;
+    showAxes?: boolean;
+    axesLength?: number;
+    axesRadius?: number;
   }
 >(function CoordinateFrame(
-  { show_axes = true, axes_length = 0.5, axes_radius = 0.0125 },
+  {
+    showAxes: show_axes = true,
+    axesLength: axes_length = 0.5,
+    axesRadius: axes_radius = 0.0125,
+  },
   ref,
 ) {
   return (
@@ -299,15 +303,15 @@ export const CoordinateFrame = React.forwardRef<
 export const CoordinateFrameBatched = React.forwardRef<
   THREE.Group,
   {
-    instance_wxyzs: Float32Array;
-    instance_positions: Float32Array;
+    wxyzsBatched: Float32Array;
+    positionsBatched: Float32Array;
     axes_length?: number;
     axes_radius?: number;
   }
 >(function CoordinateFrameBatched(
   {
-    instance_wxyzs,
-    instance_positions,
+    wxyzsBatched: instance_wxyzs,
+    positionsBatched: instance_positions,
     axes_length = 0.5,
     axes_radius = 0.0125,
   },

--- a/src/viser/client/src/WebsocketInterface.tsx
+++ b/src/viser/client/src/WebsocketInterface.tsx
@@ -13,6 +13,7 @@ import { syncSearchParamServer } from "./SearchParamsUtils";
 import {
   CameraFrustum,
   CoordinateFrame,
+  CoordinateFrameBatched,
   GlbAsset,
   OutlinesIfHovered,
   PointCloud,
@@ -145,6 +146,38 @@ function useMessageHandler() {
             <CoordinateFrame
               ref={ref}
               show_axes={message.show_axes}
+              axes_length={message.axes_length}
+              axes_radius={message.axes_radius}
+            />
+          )),
+        );
+        return;
+      }
+
+      // Add a coordinate frame.
+      case "FrameBatchedMessage": {
+        addSceneNodeMakeParents(
+          new SceneNode<THREE.Group>(message.name, (ref) => (
+            <CoordinateFrameBatched
+              ref={ref}
+              instance_wxyzs={
+                new Float32Array(
+                  message.instance_wxyzs.buffer.slice(
+                    message.instance_wxyzs.byteOffset,
+                    message.instance_wxyzs.byteOffset +
+                      message.instance_wxyzs.byteLength,
+                  ),
+                )
+              }
+              instance_positions={
+                new Float32Array(
+                  message.instance_positions.buffer.slice(
+                    message.instance_positions.byteOffset,
+                    message.instance_positions.byteOffset +
+                      message.instance_positions.byteLength,
+                  ),
+                )
+              }
               axes_length={message.axes_length}
               axes_radius={message.axes_radius}
             />

--- a/src/viser/client/src/WebsocketInterface.tsx
+++ b/src/viser/client/src/WebsocketInterface.tsx
@@ -13,7 +13,7 @@ import { syncSearchParamServer } from "./SearchParamsUtils";
 import {
   CameraFrustum,
   CoordinateFrame,
-  CoordinateFrameBatched,
+  CoordinateFrameBatched as CoordinateFramesBatched,
   GlbAsset,
   OutlinesIfHovered,
   PointCloud,
@@ -80,7 +80,7 @@ function useMessageHandler() {
     if (!(parent_name in nodeFromName)) {
       addSceneNodeMakeParents(
         new SceneNode<THREE.Group>(parent_name, (ref) => (
-          <CoordinateFrame ref={ref} show_axes={false} />
+          <CoordinateFrame ref={ref} showAxes={false} />
         )),
       );
     }
@@ -145,9 +145,9 @@ function useMessageHandler() {
           new SceneNode<THREE.Group>(message.name, (ref) => (
             <CoordinateFrame
               ref={ref}
-              show_axes={message.show_axes}
-              axes_length={message.axes_length}
-              axes_radius={message.axes_radius}
+              showAxes={message.show_axes}
+              axesLength={message.axes_length}
+              axesRadius={message.axes_radius}
             />
           )),
         );
@@ -158,23 +158,23 @@ function useMessageHandler() {
       case "FrameBatchedMessage": {
         addSceneNodeMakeParents(
           new SceneNode<THREE.Group>(message.name, (ref) => (
-            <CoordinateFrameBatched
+            <CoordinateFramesBatched
               ref={ref}
-              instance_wxyzs={
+              wxyzsBatched={
                 new Float32Array(
-                  message.instance_wxyzs.buffer.slice(
-                    message.instance_wxyzs.byteOffset,
-                    message.instance_wxyzs.byteOffset +
-                      message.instance_wxyzs.byteLength,
+                  message.wxyzs_batched.buffer.slice(
+                    message.wxyzs_batched.byteOffset,
+                    message.wxyzs_batched.byteOffset +
+                      message.wxyzs_batched.byteLength,
                   ),
                 )
               }
-              instance_positions={
+              positionsBatched={
                 new Float32Array(
-                  message.instance_positions.buffer.slice(
-                    message.instance_positions.byteOffset,
-                    message.instance_positions.byteOffset +
-                      message.instance_positions.byteLength,
+                  message.positions_batched.buffer.slice(
+                    message.positions_batched.byteOffset,
+                    message.positions_batched.byteOffset +
+                      message.positions_batched.byteLength,
                   ),
                 )
               }

--- a/src/viser/client/src/WebsocketMessages.tsx
+++ b/src/viser/client/src/WebsocketMessages.tsx
@@ -75,6 +75,21 @@ export interface FrameMessage {
   axes_length: number;
   axes_radius: number;
 }
+/** Batched coordinate frames message.
+ *
+ * Position and orientation should follow a `T_parent_local` convention, which
+ * corresponds to the R matrix and t vector in `p_parent = [R | t] p_local`.
+ *
+ * (automatically generated)
+ */
+export interface FrameBatchedMessage {
+  type: "FrameBatchedMessage";
+  name: string;
+  instance_wxyzs: Uint8Array;
+  instance_positions: Uint8Array;
+  axes_length: number;
+  axes_radius: number;
+}
 /** Grid message. Helpful for visualizing things like ground planes.
  *
  * (automatically generated)
@@ -737,6 +752,7 @@ export type Message =
   | CameraFrustumMessage
   | GlbMessage
   | FrameMessage
+  | FrameBatchedMessage
   | GridMessage
   | LabelMessage
   | Gui3DMessage

--- a/src/viser/client/src/WebsocketMessages.tsx
+++ b/src/viser/client/src/WebsocketMessages.tsx
@@ -85,8 +85,8 @@ export interface FrameMessage {
 export interface FrameBatchedMessage {
   type: "FrameBatchedMessage";
   name: string;
-  instance_wxyzs: Uint8Array;
-  instance_positions: Uint8Array;
+  wxyzs_batched: Uint8Array;
+  positions_batched: Uint8Array;
   axes_length: number;
   axes_radius: number;
 }


### PR DESCRIPTION
`.add_frame()` with `show_axes=True` in a loop works pretty well until we get above several thousand coordinate frames.

The new `.add_frames_batched()` should scale much more nicely when we have a lot frames. Here's ~1M:

![image](https://github.com/nerfstudio-project/viser/assets/6992947/84b5041d-1ae5-43b9-8994-21cec6369777)
