### PR TITLE
Fix pose update jitter issue, efficiency improvements

### DIFF
--- a/src/viser/_message_api.py
+++ b/src/viser/_message_api.py
@@ -853,8 +853,7 @@ class MessageApi(abc.ABC):
                 material=material,
             )
         )
-        node_handle = MeshHandle._make(self, name, wxyz, position, visible)
-        return node_handle
+        return MeshHandle._make(self, name, wxyz, position, visible)
 
     def add_mesh_trimesh(
         self,

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -86,6 +86,10 @@ class SceneNodeHandle:
 
         out.wxyz = wxyz
         out.position = position
+
+        # Toggle visibility to make sure we send a
+        # SetSceneNodeVisibilityMessage to the client.
+        out._impl.visible = not visible
         out.visible = visible
         return out
 

--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -64,6 +64,7 @@ export type ViewerContextContents = {
     [name: string]:
       | undefined
       | {
+          poseUpdateState?: "updated" | "needsUpdate" | "waitForMakeObject";
           wxyz?: [number, number, number, number];
           position?: [number, number, number];
           visibility?: boolean; // Visibility state from the server.


### PR DESCRIPTION
Since objects and poses are sent separately, we'd previously end up in a situation when adding a new scene node that replaces another scene node would briefly apply the new node's pose to the old one.

This caused some jitter (much worse than this at 120 FPS):
![a](https://github.com/nerfstudio-project/viser/assets/6992947/7a6d6723-acb7-41ce-b73d-504b311c0589)

Now fixed:
![b](https://github.com/nerfstudio-project/viser/assets/6992947/7aa73303-d93c-401e-8797-f130554f8846)
