### PR TITLE
Account for pixel ratio in point cloud shader

### DIFF
--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -129,7 +129,8 @@ export const PointCloud = React.forwardRef<
             Math.PI) /
             2.0,
         )) *
-      getThreeState().gl.getSize(rendererSize).height;
+      getThreeState().gl.getSize(rendererSize).height *
+      getThreeState().gl.getPixelRatio();
   });
   return <points ref={ref} geometry={geometry} material={material} />;
 });


### PR DESCRIPTION
Makes point sizes consistent across devices/displays.