### PR TITLE
(Significantly) improve performance by turning off compression for websocket messages

### DIFF
--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -365,6 +365,7 @@ class Server(MessageHandler):
                         serve,
                         host,
                         port,
+                        compression=None,
                         process_request=(
                             viser_http_server if http_server_root is not None else None
                         ),


### PR DESCRIPTION
Compression introduces a CPU bottleneck on the frontend when we want to add a lot of large assets, like meshes and point clouds. I tried tuning but was unsuccessful.