### PR TITLE
Update camera on r3f canvas change, not window

### DIFF
--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -114,17 +114,15 @@ export function SynchronizedCameraControls() {
   }, [connected, sendCamera]);
 
   // Send camera for 3D viewport changes.
+  const canvas = viewer.canvasRef.current!;  // R3F canvas.
   React.useEffect(() => {
     // Create a resize observer to resize the CSS canvas when the window is resized.
     const resizeObserver = new ResizeObserver(() => { sendCamera() });
-
-    // Observe the r3f viewer canvas.
-    const canvas = viewer.canvasRef.current!;
     resizeObserver.observe(canvas);
 
     // Cleanup.
     return () => resizeObserver.disconnect();
-  }, [camera]);
+  }, [canvas]);
 
   // Keyboard controls.
   React.useEffect(() => {

--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -88,7 +88,6 @@ export function SynchronizedCameraControls() {
 
     T_world_camera.decompose(t_world_camera, R_world_camera, scale);
 
-    console.log("foo");
     sendCameraThrottled({
       type: "ViewerCameraMessage",
       wxyz: [

--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -118,11 +118,11 @@ export function SynchronizedCameraControls() {
     // Create a resize observer to resize the CSS canvas when the window is resized.
     const resizeObserver = new ResizeObserver(() => { sendCamera() });
 
-    // Observe the canvas.
-    const canvas = viewer.canvasRef.current!  // r3f viewer canvas
+    // Observe the r3f viewer canvas.
+    const canvas = viewer.canvasRef.current!;
     resizeObserver.observe(canvas);
 
-    // Cleanup
+    // Cleanup.
     return () => resizeObserver.disconnect();
   }, [camera]);
 

--- a/src/viser/client/src/CameraControls.tsx
+++ b/src/viser/client/src/CameraControls.tsx
@@ -88,6 +88,7 @@ export function SynchronizedCameraControls() {
 
     T_world_camera.decompose(t_world_camera, R_world_camera, scale);
 
+    console.log("foo");
     sendCameraThrottled({
       type: "ViewerCameraMessage",
       wxyz: [
@@ -113,11 +114,17 @@ export function SynchronizedCameraControls() {
     setTimeout(() => sendCamera(), 50);
   }, [connected, sendCamera]);
 
+  // Send camera for 3D viewport changes.
   React.useEffect(() => {
-    window.addEventListener("resize", sendCamera);
-    return () => {
-      window.removeEventListener("resize", sendCamera);
-    };
+    // Create a resize observer to resize the CSS canvas when the window is resized.
+    const resizeObserver = new ResizeObserver(() => { sendCamera() });
+
+    // Observe the canvas.
+    const canvas = viewer.canvasRef.current!  // r3f viewer canvas
+    resizeObserver.observe(canvas);
+
+    // Cleanup
+    return () => resizeObserver.disconnect();
   }, [camera]);
 
   // Keyboard controls.


### PR DESCRIPTION
Previously, a `ViewerCameraMessage` (for camera pose updates) would be triggered on *window* size, not the *canvas* element size. 

So, if the canvas size was changed due to collapsing/uncollapsing sidebars, the window size is unchanged. Thus, no message would be sent to the python side to reflect the canvas size or the aspect ratio. 

This code uses ResizeObserver to track the canvas size. 