### PR TITLE
Ship client source with package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ examples = [
 "GitHub" = "https://github.com/nerfstudio-project/viser"
 
 [tool.setuptools.package-data]
-viser = ["py.typed", "*.pyi", "_icons/tabler-icons.tar", "client/build/**/*"]
+viser = ["py.typed", "*.pyi", "_icons/tabler-icons.tar", "client/**/*"]
 
 [project.scripts]
 viser-dev-checks = "viser.scripts.dev_checks:entrypoint"


### PR DESCRIPTION
I noticed that you cannot install viser using the `pip install git+url` pattern, since only the client build files are included.

The follow fixes this, allowing `pip install git+url`, but I guess at the expense of a more bloated package? 

Feel free to discard if this is not desired :)