### PR TITLE
Fix `.add_image()` race condition

### DIFF
--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -327,7 +327,6 @@ export function SceneNodeThreeObject(props: {
               });
             }}
             onPointerOver={(e) => {
-              console.log("over");
               if (!isDisplayed()) return;
               e.stopPropagation();
               setHovered(true);


### PR DESCRIPTION
If textures weren't loaded quickly enough, `addSceneNodeMakeParents` could be called after `SetPosition`, `SetOrientation` messages were processed. This would incorrectly overwrite them.