### PR TITLE
Allow users to set logging verbosity explicitly from viser server

### DIFF
--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -419,6 +419,7 @@ class ViserServer(_BackwardsCompatibilityShim if not TYPE_CHECKING else object):
         host: str = "0.0.0.0",
         port: int = 8080,
         label: str | None = None,
+        verbose: bool = True,
         **_deprecated_kwargs,
     ):
         # Create server.
@@ -427,6 +428,7 @@ class ViserServer(_BackwardsCompatibilityShim if not TYPE_CHECKING else object):
             port=port,
             message_class=_messages.Message,
             http_server_root=Path(__file__).absolute().parent / "client" / "build",
+            verbose=verbose,
             client_api_version=1,
         )
         self._websock_server = server


### PR DESCRIPTION
This PR wants to expose `verbose` arguement to users when creating viewer server, it can be used by setting `verbose=False` such that the message logging does not show up. 

This is useful for for-loop-based applications when there are other text loggings being printed out constantly and reduces clutering.