### PR TITLE
Default mime type to application/octet-stream for unrecognized file types

### DIFF
--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -357,7 +357,7 @@ class ClientHandle(_BackwardsCompatibilityShim if not TYPE_CHECKING else object)
         """
         mime_type = mimetypes.guess_type(filename, strict=False)[0]
         if mime_type is None:
-            mime_type = 'application/octet-stream'
+            mime_type = "application/octet-stream"
 
         from ._gui_api import _make_unique_id
 

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -356,9 +356,8 @@ class ClientHandle(_BackwardsCompatibilityShim if not TYPE_CHECKING else object)
             chunk_size: Number of bytes to send at a time.
         """
         mime_type = mimetypes.guess_type(filename, strict=False)[0]
-        assert (
-            mime_type is not None
-        ), f"Could not guess MIME type from filename {filename}!"
+        if mime_type is None:
+            mime_type = 'application/octet-stream'
 
         from ._gui_api import _make_unique_id
 

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -392,11 +392,11 @@ class WebsockServer(WebsockMessageHandler):
 
             use_gzip = "gzip" in request_headers.get("Accept-Encoding", "")
 
-            mime_type = mimetypes.MimeTypes().guess_type(relpath)[0]
+            mime_type = mimetypes.guess_type(relpath)[0]
             if mime_type is None:
                 mime_type = "application/octet-stream"
             response_headers = {
-                "Content-Type": str(mime_type),
+                "Content-Type": mime_type,
             }
 
             if source_path not in file_cache:

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -92,7 +92,8 @@ class WebsockMessageHandler:
                 cb(client_id, message)
 
     @abc.abstractmethod
-    def unsafe_send_message(self, message: Message) -> None: ...
+    def unsafe_send_message(self, message: Message) -> None:
+        ...
 
     def queue_message(self, message: Message) -> None:
         """Wrapped method for sending messages safely."""
@@ -392,8 +393,11 @@ class WebsockServer(WebsockMessageHandler):
 
             use_gzip = "gzip" in request_headers.get("Accept-Encoding", "")
 
+            mime_type = mimetypes.MimeTypes().guess_type(relpath)[0]
+            if mime_type is None:
+                mime_type = "application/octet-stream"
             response_headers = {
-                "Content-Type": str(mimetypes.MimeTypes().guess_type(relpath)[0]),
+                "Content-Type": str(mime_type),
             }
 
             if source_path not in file_cache:

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -92,8 +92,7 @@ class WebsockMessageHandler:
                 cb(client_id, message)
 
     @abc.abstractmethod
-    def unsafe_send_message(self, message: Message) -> None:
-        ...
+    def unsafe_send_message(self, message: Message) -> None: ...
 
     def queue_message(self, message: Message) -> None:
         """Wrapped method for sending messages safely."""


### PR DESCRIPTION
Set the default file type instead of throwing an exception for unrecognized file types. Used in nerfstudio-project/nerfstudio#3220 in order to directly download `.ply` files.