### PR TITLE
Fix context forwarding for 3D GUI containers

### DIFF
--- a/examples/15_gui_in_scene.py
+++ b/examples/15_gui_in_scene.py
@@ -13,6 +13,7 @@ import viser
 import viser.transforms as tf
 
 server = viser.ViserServer()
+server.gui.configure_theme(dark_mode=True)
 num_frames = 20
 
 

--- a/src/viser/client/package.json
+++ b/src/viser/client/package.json
@@ -25,6 +25,7 @@
     "dayjs": "^1.11.10",
     "hold-event": "^1.1.0",
     "immer": "^10.0.4",
+    "its-fine": "^1.2.5",
     "mantine-react-table": "^2.0.0-beta.0",
     "msgpackr": "^1.8.5",
     "postcss": "^8.4.38",

--- a/src/viser/client/src/ControlPanel/FloatingPanel.tsx
+++ b/src/viser/client/src/ControlPanel/FloatingPanel.tsx
@@ -121,7 +121,8 @@ export default function FloatingPanel({
           parent.clientHeight,
         );
 
-      const newMaxHeight = parent.clientHeight - panelBoundaryPad * 2 - 2.5 * 16;
+      const newMaxHeight =
+        parent.clientHeight - panelBoundaryPad * 2 - 2.5 * 16;
       maxHeight !== newMaxHeight && setMaxHeight(newMaxHeight);
 
       let newX = unfixedOffset.current.x;

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -1,4 +1,4 @@
-import { Instance, Instances, shaderMaterial } from "@react-three/drei";
+import { Instance, Instances, shaderMaterial, Html } from "@react-three/drei";
 import { createPortal, useFrame, useThree } from "@react-three/fiber";
 import { Outlines } from "./Outlines";
 import React from "react";

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -1,4 +1,4 @@
-import { Instance, Instances, shaderMaterial, Html } from "@react-three/drei";
+import { Instance, Instances, shaderMaterial } from "@react-three/drei";
 import { createPortal, useFrame, useThree } from "@react-three/fiber";
 import { Outlines } from "./Outlines";
 import React from "react";

--- a/src/viser/client/src/WebsocketInterface.tsx
+++ b/src/viser/client/src/WebsocketInterface.tsx
@@ -1,6 +1,7 @@
 import AwaitLock from "await-lock";
-import { CatmullRomLine, CubicBezierLine, Grid } from "@react-three/drei";
+import { CatmullRomLine, CubicBezierLine, Grid, Html } from "@react-three/drei";
 import { unpack } from "msgpackr";
+import { useContextBridge } from "its-fine";
 import { notifications } from "@mantine/notifications";
 
 import React, { useContext } from "react";
@@ -23,7 +24,7 @@ import {
   FileTransferStart,
   Message,
 } from "./WebsocketMessages";
-import { Html, PivotControls } from "@react-three/drei";
+import { PivotControls } from "@react-three/drei";
 import {
   isTexture,
   makeThrottledMessageSender,
@@ -32,10 +33,9 @@ import {
 import { isGuiConfig } from "./ControlPanel/GuiState";
 import { useFrame } from "@react-three/fiber";
 import GeneratedGuiContainer from "./ControlPanel/Generated";
-import { MantineProvider, Paper, Progress } from "@mantine/core";
+import { Paper, Progress } from "@mantine/core";
 import { IconCheck } from "@tabler/icons-react";
 import { computeT_threeworld_world } from "./WorldTransformUtils";
-import { theme } from "./AppTheme";
 
 /** Convert raw RGB color buffers to linear color buffers. **/
 function threeColorBufferFromUint8Buffer(colors: ArrayBuffer) {
@@ -55,6 +55,7 @@ function threeColorBufferFromUint8Buffer(colors: ArrayBuffer) {
 /** Returns a handler for all incoming messages. */
 function useMessageHandler() {
   const viewer = useContext(ViewerContext)!;
+  const ContextBridge = useContextBridge();
 
   // We could reduce the redundancy here if we wanted to.
   // https://github.com/nerfstudio-project/viser/issues/39
@@ -657,8 +658,8 @@ function useMessageHandler() {
               // after the component is mounted.
               return (
                 <group ref={ref} position={new THREE.Vector3(1e8, 1e8, 1e8)}>
-                  <Html prepend={false}>
-                    <MantineProvider theme={theme}>
+                  <Html>
+                    <ContextBridge>
                       <Paper
                         style={{
                           width: "18em",
@@ -678,7 +679,7 @@ function useMessageHandler() {
                           />
                         </ViewerContext.Provider>
                       </Paper>
-                    </MantineProvider>
+                    </ContextBridge>
                   </Html>
                 </group>
               );

--- a/src/viser/client/yarn.lock
+++ b/src/viser/client/yarn.lock
@@ -3033,7 +3033,7 @@ iterator.prototype@^1.1.2:
     reflect.getprototypeof "^1.0.4"
     set-function-name "^2.0.1"
 
-its-fine@^1.0.6:
+its-fine@^1.0.6, its-fine@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/its-fine/-/its-fine-1.2.5.tgz#5466c287f86a0a73e772c8d8d515626c97195dc9"
   integrity sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==


### PR DESCRIPTION
Fixes a dark mode reset bug, spotted by @ginazhouhuiwu:

https://github.com/nerfstudio-project/viser/assets/6992947/1ad9f71e-293e-4eef-9ab0-9a7f05312860

This likely broke from a recent Mantine upgrade.
