### PR TITLE
Scene tree refactor

### DIFF
--- a/docs/source/scene_handles.md
+++ b/docs/source/scene_handles.md
@@ -11,8 +11,8 @@ connected clients. When a scene node is added to a client (for example, via
 The most common attributes to read and write here are
 :attr:`viser.SceneNodeHandle.wxyz` and :attr:`viser.SceneNodeHandle.position`.
 Each node type also has type-specific attributes that we can read and write.
-Note that many of these are lower-level than their equivalent arguments in
-factory methods like :func:`viser.ViserServer.add_frame()` or
+Many of these are lower-level than their equivalent arguments in factory
+methods like :func:`viser.ViserServer.add_frame()` or
 :func:`viser.ViserServer.add_image()`.
 
 <!-- prettier-ignore-start -->

--- a/docs/source/scene_handles.md
+++ b/docs/source/scene_handles.md
@@ -8,6 +8,13 @@ When a scene node is added to a server (for example, via
 connected clients. When a scene node is added to a client (for example, via
 :func:`viser.ClientHandle.add_frame()`), state is local to a specific client.
 
+The most common attributes to read and write here are
+:attr:`viser.SceneNodeHandle.wxyz` and :attr:`viser.SceneNodeHandle.position`.
+Each node type also has type-specific attributes that we can read and write.
+Note that many of these are lower-level than their equivalent arguments in
+factory methods like :func:`viser.ViserServer.add_frame()` or
+:func:`viser.ViserServer.add_image()`.
+
 <!-- prettier-ignore-start -->
 
 .. autoclass:: viser.SceneNodeHandle

--- a/docs/source/scene_handles.md
+++ b/docs/source/scene_handles.md
@@ -41,6 +41,10 @@ methods like :func:`viser.ViserServer.add_frame()` or
 
 .. autoclass:: viser.PointCloudHandle
 
+.. autoclass:: viser.SplineCatmullRomHandle
+
+.. autoclass:: viser.SplineCubicBezierHandle
+
 .. autoclass:: viser.TransformControlsHandle
 
 .. autoclass:: viser.GaussianSplatHandle

--- a/examples/25_smpl_visualizer_skinned.py
+++ b/examples/25_smpl_visualizer_skinned.py
@@ -175,6 +175,9 @@ def make_gui_elements(
         gui_rgb = server.gui.add_rgb("Color", initial_value=(90, 200, 255))
         gui_wireframe = server.gui.add_checkbox("Wireframe", initial_value=False)
         gui_show_controls = server.gui.add_checkbox("Handles", initial_value=True)
+        gui_control_size = server.gui.add_slider(
+            "Handle size", min=0.0, max=10.0, step=0.01, initial_value=1.0
+        )
 
         gui_rgb.on_update(set_changed)
         gui_wireframe.on_update(set_changed)
@@ -183,6 +186,16 @@ def make_gui_elements(
         def _(_):
             for control in transform_controls:
                 control.visible = gui_show_controls.value
+
+        @gui_control_size.on_update
+        def _(_):
+            for control in transform_controls:
+                prefixed_joint_name = control.name
+                control.scale = (
+                    0.2
+                    * (0.75 ** prefixed_joint_name.count("/"))
+                    * gui_control_size.value
+                )
 
     # GUI elements: shape parameters.
     with tab_group.add_tab("Shape", viser.Icon.BOX):

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -44,7 +44,7 @@ from ._gui_handles import (
 )
 from ._icons import svg_from_icon
 from ._icons_enum import IconName
-from ._messages import FileTransferPartAck
+from ._messages import FileTransferPartAck, GuiSliderMark
 from ._scene_api import cast_vector
 
 if TYPE_CHECKING:
@@ -1278,9 +1278,9 @@ class GuiApi:
                 visible=visible,
                 disabled=disabled,
                 marks=tuple(
-                    {"value": float(x[0]), "label": x[1]}
+                    GuiSliderMark(value=float(x[0]), label=x[1])
                     if isinstance(x, tuple)
-                    else {"value": float(x)}
+                    else GuiSliderMark(value=x, label=None)
                     for x in marks
                 )
                 if marks is not None
@@ -1361,9 +1361,9 @@ class GuiApi:
                 fixed_endpoints=fixed_endpoints,
                 precision=_compute_precision_digits(step),
                 marks=tuple(
-                    {"value": float(x[0]), "label": x[1]}
+                    GuiSliderMark(value=float(x[0]), label=x[1])
                     if isinstance(x, tuple)
-                    else {"value": float(x)}
+                    else GuiSliderMark(value=x, label=None)
                     for x in marks
                 )
                 if marks is not None

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -5,17 +5,7 @@ from __future__ import annotations
 
 import dataclasses
 import uuid
-from typing import (
-    Any,
-    Callable,
-    ClassVar,
-    Dict,
-    Optional,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, ClassVar, Dict, Optional, Tuple, Type, TypeVar, Union
 
 import numpy as onp
 import numpy.typing as onpt
@@ -67,18 +57,17 @@ class Message(infra.Message):
 
         return "_".join(parts)
 
+    @classmethod
+    def __init_subclass__(
+        cls, tag: Literal[None, "GuiAddComponentMessage", "SceneNodeMessage"] = None
+    ):
+        """Tag will be used to create a union type in TypeScript."""
+        super().__init_subclass__()
+        if tag is not None:
+            cls._tags = cls._tags + (tag,)
+
 
 T = TypeVar("T", bound=Type[Message])
-
-
-def tag_class(tag: str) -> Callable[[T], T]:
-    """Decorator for tagging a class with a `type` field."""
-
-    def wrapper(cls: T) -> T:
-        cls._tags = (cls._tags or ()) + (tag,)
-        return cls
-
-    return wrapper
 
 
 @dataclasses.dataclass
@@ -162,7 +151,7 @@ class ScenePointerEnableMessage(Message):
 
 
 @dataclasses.dataclass
-class CameraFrustumMessage(Message):
+class CameraFrustumMessage(Message, tag="SceneNodeMessage"):
     """Variant of CameraMessage used for visualizing camera frustums.
 
     OpenCV convention, +Z forward."""
@@ -177,7 +166,7 @@ class CameraFrustumMessage(Message):
 
 
 @dataclasses.dataclass
-class GlbMessage(Message):
+class GlbMessage(Message, tag="SceneNodeMessage"):
     """GlTF message."""
 
     name: str
@@ -186,7 +175,7 @@ class GlbMessage(Message):
 
 
 @dataclasses.dataclass
-class FrameMessage(Message):
+class FrameMessage(Message, tag="SceneNodeMessage"):
     """Coordinate frame message."""
 
     name: str
@@ -197,7 +186,7 @@ class FrameMessage(Message):
 
 
 @dataclasses.dataclass
-class BatchedAxesMessage(Message):
+class BatchedAxesMessage(Message, tag="SceneNodeMessage"):
     """Batched axes message.
 
     Positions and orientations should follow a `T_parent_local` convention, which
@@ -211,7 +200,7 @@ class BatchedAxesMessage(Message):
 
 
 @dataclasses.dataclass
-class GridMessage(Message):
+class GridMessage(Message, tag="SceneNodeMessage"):
     """Grid message. Helpful for visualizing things like ground planes."""
 
     name: str
@@ -233,7 +222,7 @@ class GridMessage(Message):
 
 
 @dataclasses.dataclass
-class LabelMessage(Message):
+class LabelMessage(Message, tag="SceneNodeMessage"):
     """Add a 2D label to the scene."""
 
     name: str
@@ -241,7 +230,7 @@ class LabelMessage(Message):
 
 
 @dataclasses.dataclass
-class Gui3DMessage(Message):
+class Gui3DMessage(Message, tag="SceneNodeMessage"):
     """Add a 3D gui element to the scene."""
 
     order: float
@@ -250,7 +239,7 @@ class Gui3DMessage(Message):
 
 
 @dataclasses.dataclass
-class PointCloudMessage(Message):
+class PointCloudMessage(Message, tag="SceneNodeMessage"):
     """Point cloud message.
 
     Positions are internally canonicalized to float32, colors to uint8.
@@ -275,14 +264,7 @@ class PointCloudMessage(Message):
 
 
 @dataclasses.dataclass
-class MeshBoneMessage(Message):
-    """Message for a bone of a skinned mesh."""
-
-    name: str
-
-
-@dataclasses.dataclass
-class MeshMessage(Message):
+class MeshMessage(Message, tag="SceneNodeMessage"):
     """Mesh message.
 
     Vertices are internally canonicalized to float32, faces to uint32."""
@@ -451,7 +433,7 @@ class BackgroundImageMessage(Message):
 
 
 @dataclasses.dataclass
-class ImageMessage(Message):
+class ImageMessage(Message, tag="SceneNodeMessage"):
     """Message for rendering 2D images."""
 
     name: str
@@ -506,9 +488,9 @@ class ResetGuiMessage(Message):
     """Reset GUI."""
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddFolderMessage(Message):
+class GuiAddFolderMessage(Message, tag="GuiAddComponentMessage"):
+    order: float
     order: float
     id: str
     label: str
@@ -517,9 +499,9 @@ class GuiAddFolderMessage(Message):
     visible: bool
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddMarkdownMessage(Message):
+class GuiAddMarkdownMessage(Message, tag="GuiAddComponentMessage"):
+    order: float
     order: float
     id: str
     markdown: str
@@ -527,9 +509,9 @@ class GuiAddMarkdownMessage(Message):
     visible: bool
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddProgressBarMessage(Message):
+class GuiAddProgressBarMessage(Message, tag="GuiAddComponentMessage"):
+    order: float
     order: float
     id: str
     value: float
@@ -539,9 +521,9 @@ class GuiAddProgressBarMessage(Message):
     visible: bool
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddPlotlyMessage(Message):
+class GuiAddPlotlyMessage(Message, tag="GuiAddComponentMessage"):
+    order: float
     order: float
     id: str
     plotly_json_str: str
@@ -550,9 +532,9 @@ class GuiAddPlotlyMessage(Message):
     visible: bool
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddTabGroupMessage(Message):
+class GuiAddTabGroupMessage(Message, tag="GuiAddComponentMessage"):
+    order: float
     order: float
     id: str
     container_id: str
@@ -588,9 +570,9 @@ class GuiCloseModalMessage(Message):
     id: str
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddButtonMessage(_GuiAddInputBase):
+class GuiAddButtonMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    # All GUI elements currently need an `value` field.
     # All GUI elements currently need an `value` field.
     # This makes our job on the frontend easier.
     value: bool
@@ -598,17 +580,17 @@ class GuiAddButtonMessage(_GuiAddInputBase):
     icon_html: Optional[str]
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddUploadButtonMessage(_GuiAddInputBase):
+class GuiAddUploadButtonMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    color: Optional[Color]
     color: Optional[Color]
     icon_html: Optional[str]
     mime_type: str
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddSliderMessage(_GuiAddInputBase):
+class GuiAddSliderMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    min: float
     min: float
     max: float
     step: Optional[float]
@@ -617,9 +599,9 @@ class GuiAddSliderMessage(_GuiAddInputBase):
     marks: Optional[Tuple[GuiSliderMark, ...]] = None
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddMultiSliderMessage(_GuiAddInputBase):
+class GuiAddMultiSliderMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    min: float
     min: float
     max: float
     step: Optional[float]
@@ -629,9 +611,9 @@ class GuiAddMultiSliderMessage(_GuiAddInputBase):
     marks: Optional[Tuple[GuiSliderMark, ...]] = None
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddNumberMessage(_GuiAddInputBase):
+class GuiAddNumberMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    value: float
     value: float
     precision: int
     step: float
@@ -639,27 +621,27 @@ class GuiAddNumberMessage(_GuiAddInputBase):
     max: Optional[float]
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddRgbMessage(_GuiAddInputBase):
+class GuiAddRgbMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    value: Tuple[int, int, int]
     value: Tuple[int, int, int]
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddRgbaMessage(_GuiAddInputBase):
+class GuiAddRgbaMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    value: Tuple[int, int, int, int]
     value: Tuple[int, int, int, int]
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddCheckboxMessage(_GuiAddInputBase):
+class GuiAddCheckboxMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    value: bool
     value: bool
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddVector2Message(_GuiAddInputBase):
+class GuiAddVector2Message(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    value: Tuple[float, float]
     value: Tuple[float, float]
     min: Optional[Tuple[float, float]]
     max: Optional[Tuple[float, float]]
@@ -667,9 +649,9 @@ class GuiAddVector2Message(_GuiAddInputBase):
     precision: int
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddVector3Message(_GuiAddInputBase):
+class GuiAddVector3Message(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    value: Tuple[float, float, float]
     value: Tuple[float, float, float]
     min: Optional[Tuple[float, float, float]]
     max: Optional[Tuple[float, float, float]]
@@ -677,22 +659,22 @@ class GuiAddVector3Message(_GuiAddInputBase):
     precision: int
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddTextMessage(_GuiAddInputBase):
+class GuiAddTextMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    value: str
     value: str
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddDropdownMessage(_GuiAddInputBase):
+class GuiAddDropdownMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    value: str
     value: str
     options: Tuple[str, ...]
 
 
-@tag_class("GuiAddComponentMessage")
 @dataclasses.dataclass
-class GuiAddButtonGroupMessage(_GuiAddInputBase):
+class GuiAddButtonGroupMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
+    value: str
     value: str
     options: Tuple[str, ...]
 
@@ -740,7 +722,7 @@ class ThemeConfigurationMessage(Message):
 
 
 @dataclasses.dataclass
-class CatmullRomSplineMessage(Message):
+class CatmullRomSplineMessage(Message, tag="SceneNodeMessage"):
     """Message from server->client carrying Catmull-Rom spline information."""
 
     name: str
@@ -754,7 +736,7 @@ class CatmullRomSplineMessage(Message):
 
 
 @dataclasses.dataclass
-class CubicBezierSplineMessage(Message):
+class CubicBezierSplineMessage(Message, tag="SceneNodeMessage"):
     """Message from server->client carrying Cubic Bezier spline information."""
 
     name: str
@@ -766,7 +748,7 @@ class CubicBezierSplineMessage(Message):
 
 
 @dataclasses.dataclass
-class GaussianSplatsMessage(Message):
+class GaussianSplatsMessage(Message, tag="SceneNodeMessage"):
     """Message from server->client carrying splattable Gaussians."""
 
     name: str

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -342,7 +342,7 @@ class SetBonePositionMessage(Message):
 
 
 @dataclasses.dataclass
-class TransformControlsMessage(Message):
+class TransformControlsMessage(Message, tag="SceneNodeMessage"):
     """Message for transform gizmos."""
 
     name: str

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -174,8 +174,8 @@ class CameraFrustumProps:
     """Aspect ratio of the camera (width over height). For handles, synchronized automatically when assigned."""
     scale: float
     """Scale factor for the size of the frustum. For handles, synchronized automatically when assigned."""
-    color: int
-    """Color of the frustum as an RGB integer. For handles, synchronized automatically when assigned."""
+    color: Tuple[int, int, int]
+    """Color of the frustum as RGB integers. For handles, synchronized automatically when assigned."""
     image_media_type: Optional[Literal["image/jpeg", "image/png"]]
     """Format of the provided image ('image/jpeg' or 'image/png'). For handles, synchronized automatically when assigned."""
     image_binary: Optional[bytes]
@@ -261,14 +261,14 @@ class GridProps:
     """Number of segments along the height. For handles, synchronized automatically when assigned."""
     plane: Literal["xz", "xy", "yx", "yz", "zx", "zy"]
     """The plane in which the grid is oriented. For handles, synchronized automatically when assigned."""
-    cell_color: int
-    """Color of the grid cells as an RGB integer. For handles, synchronized automatically when assigned."""
+    cell_color: Tuple[int, int, int]
+    """Color of the grid cells as RGB integers. For handles, synchronized automatically when assigned."""
     cell_thickness: float
     """Thickness of the grid lines. For handles, synchronized automatically when assigned."""
     cell_size: float
     """Size of each cell in the grid. For handles, synchronized automatically when assigned."""
-    section_color: int
-    """Color of the grid sections as an RGB integer. For handles, synchronized automatically when assigned."""
+    section_color: Tuple[int, int, int]
+    """Color of the grid sections as RGB integers. For handles, synchronized automatically when assigned."""
     section_thickness: float
     """Thickness of the section lines. For handles, synchronized automatically when assigned."""
     section_size: float
@@ -355,8 +355,8 @@ class MeshProps:
     """A numpy array of vertex positions. Should have shape (V, 3). For handles, synchronized automatically when assigned."""
     faces: onpt.NDArray[onp.uint32]
     """A numpy array of faces, where each face is represented by indices of vertices. Should have shape (F, 3). For handles, synchronized automatically when assigned."""
-    color: Optional[int]
-    """Color of the mesh as an RGB integer. For handles, synchronized automatically when assigned."""
+    color: Optional[Tuple[int, int, int]]
+    """Color of the mesh as RGB integers. For handles, synchronized automatically when assigned."""
     vertex_colors: Optional[onpt.NDArray[onp.uint8]]
     """Optional array of vertex colors. For handles, synchronized automatically when assigned."""
     wireframe: bool
@@ -871,8 +871,8 @@ class CatmullRomSplineProps:
     """Boolean indicating if the spline is closed (forms a loop). For handles, synchronized automatically when assigned."""
     line_width: float
     """Width of the spline line. For handles, synchronized automatically when assigned."""
-    color: int
-    """Color of the spline as an RGB integer. For handles, synchronized automatically when assigned."""
+    color: Tuple[int, int, int]
+    """Color of the spline as RGB integers. For handles, synchronized automatically when assigned."""
     segments: Optional[int]
     """Number of segments to divide the spline into. For handles, synchronized automatically when assigned."""
 
@@ -893,8 +893,8 @@ class CubicBezierSplineProps:
     """A tuple of control points for Bezier curve shaping. For handles, synchronized automatically when assigned."""
     line_width: float
     """Width of the spline line. For handles, synchronized automatically when assigned."""
-    color: int
-    """Color of the spline as an RGB integer. For handles, synchronized automatically when assigned."""
+    color: Tuple[int, int, int]
+    """Color of the spline as RGB integers. For handles, synchronized automatically when assigned."""
     segments: Optional[int]
     """Number of segments to divide the spline into. For handles, synchronized automatically when assigned."""
 

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -617,7 +617,6 @@ class ResetGuiMessage(Message):
 @dataclasses.dataclass
 class GuiAddFolderMessage(Message, tag="GuiAddComponentMessage"):
     order: float
-    order: float
     id: str
     label: str
     container_id: str
@@ -628,7 +627,6 @@ class GuiAddFolderMessage(Message, tag="GuiAddComponentMessage"):
 @dataclasses.dataclass
 class GuiAddMarkdownMessage(Message, tag="GuiAddComponentMessage"):
     order: float
-    order: float
     id: str
     markdown: str
     container_id: str
@@ -637,7 +635,6 @@ class GuiAddMarkdownMessage(Message, tag="GuiAddComponentMessage"):
 
 @dataclasses.dataclass
 class GuiAddProgressBarMessage(Message, tag="GuiAddComponentMessage"):
-    order: float
     order: float
     id: str
     value: float
@@ -650,7 +647,6 @@ class GuiAddProgressBarMessage(Message, tag="GuiAddComponentMessage"):
 @dataclasses.dataclass
 class GuiAddPlotlyMessage(Message, tag="GuiAddComponentMessage"):
     order: float
-    order: float
     id: str
     plotly_json_str: str
     aspect: float
@@ -660,7 +656,6 @@ class GuiAddPlotlyMessage(Message, tag="GuiAddComponentMessage"):
 
 @dataclasses.dataclass
 class GuiAddTabGroupMessage(Message, tag="GuiAddComponentMessage"):
-    order: float
     order: float
     id: str
     container_id: str
@@ -699,7 +694,6 @@ class GuiCloseModalMessage(Message):
 @dataclasses.dataclass
 class GuiAddButtonMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
     # All GUI elements currently need an `value` field.
-    # All GUI elements currently need an `value` field.
     # This makes our job on the frontend easier.
     value: bool
     color: Optional[Color]
@@ -709,14 +703,12 @@ class GuiAddButtonMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
 @dataclasses.dataclass
 class GuiAddUploadButtonMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
     color: Optional[Color]
-    color: Optional[Color]
     icon_html: Optional[str]
     mime_type: str
 
 
 @dataclasses.dataclass
 class GuiAddSliderMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
-    min: float
     min: float
     max: float
     step: Optional[float]
@@ -727,7 +719,6 @@ class GuiAddSliderMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
 
 @dataclasses.dataclass
 class GuiAddMultiSliderMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
-    min: float
     min: float
     max: float
     step: Optional[float]
@@ -740,7 +731,6 @@ class GuiAddMultiSliderMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
 @dataclasses.dataclass
 class GuiAddNumberMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
     value: float
-    value: float
     precision: int
     step: float
     min: Optional[float]
@@ -750,24 +740,20 @@ class GuiAddNumberMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
 @dataclasses.dataclass
 class GuiAddRgbMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
     value: Tuple[int, int, int]
-    value: Tuple[int, int, int]
 
 
 @dataclasses.dataclass
 class GuiAddRgbaMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
-    value: Tuple[int, int, int, int]
     value: Tuple[int, int, int, int]
 
 
 @dataclasses.dataclass
 class GuiAddCheckboxMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
     value: bool
-    value: bool
 
 
 @dataclasses.dataclass
 class GuiAddVector2Message(_GuiAddInputBase, tag="GuiAddComponentMessage"):
-    value: Tuple[float, float]
     value: Tuple[float, float]
     min: Optional[Tuple[float, float]]
     max: Optional[Tuple[float, float]]
@@ -778,7 +764,6 @@ class GuiAddVector2Message(_GuiAddInputBase, tag="GuiAddComponentMessage"):
 @dataclasses.dataclass
 class GuiAddVector3Message(_GuiAddInputBase, tag="GuiAddComponentMessage"):
     value: Tuple[float, float, float]
-    value: Tuple[float, float, float]
     min: Optional[Tuple[float, float, float]]
     max: Optional[Tuple[float, float, float]]
     step: float
@@ -788,19 +773,16 @@ class GuiAddVector3Message(_GuiAddInputBase, tag="GuiAddComponentMessage"):
 @dataclasses.dataclass
 class GuiAddTextMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
     value: str
-    value: str
 
 
 @dataclasses.dataclass
 class GuiAddDropdownMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
-    value: str
     value: str
     options: Tuple[str, ...]
 
 
 @dataclasses.dataclass
 class GuiAddButtonGroupMessage(_GuiAddInputBase, tag="GuiAddComponentMessage"):
-    value: str
     value: str
     options: Tuple[str, ...]
 

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -169,11 +169,17 @@ class CameraFrustumMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class CameraFrustumProps:
     fov: float
+    """Field of view of the camera (in radians). For handles, synchronized automatically when assigned."""
     aspect: float
+    """Aspect ratio of the camera (width over height). For handles, synchronized automatically when assigned."""
     scale: float
+    """Scale factor for the size of the frustum. For handles, synchronized automatically when assigned."""
     color: int
+    """Color of the frustum as an RGB integer. For handles, synchronized automatically when assigned."""
     image_media_type: Optional[Literal["image/jpeg", "image/png"]]
+    """Format of the provided image ('image/jpeg' or 'image/png'). For handles, synchronized automatically when assigned."""
     image_binary: Optional[bytes]
+    """Optional image to be displayed on the frustum. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -187,7 +193,9 @@ class GlbMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class GlbProps:
     glb_data: bytes
+    """A binary payload containing the GLB data. For handles, synchronized automatically when assigned."""
     scale: float
+    """A scale for resizing the GLB asset. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -201,9 +209,13 @@ class FrameMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class FrameProps:
     show_axes: bool
+    """Boolean to indicate whether to show the frame as a set of axes + origin sphere. For handles, synchronized automatically when assigned."""
     axes_length: float
+    """Length of each axis. For handles, synchronized automatically when assigned."""
     axes_radius: float
+    """Radius of each axis. For handles, synchronized automatically when assigned."""
     origin_radius: float
+    """Radius of the origin sphere. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -220,9 +232,13 @@ class BatchedAxesMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class BatchedAxesProps:
     wxyzs_batched: onpt.NDArray[onp.float32]
+    """Float array of shape (N,4) representing quaternion rotations. For handles, synchronized automatically when assigned."""
     positions_batched: onpt.NDArray[onp.float32]
+    """Float array of shape (N,3) representing positions. For handles, synchronized automatically when assigned."""
     axes_length: float
+    """Length of each axis. For handles, synchronized automatically when assigned."""
     axes_radius: float
+    """Radius of each axis. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -236,16 +252,27 @@ class GridMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class GridProps:
     width: float
+    """Width of the grid. For handles, synchronized automatically when assigned."""
     height: float
+    """Height of the grid. For handles, synchronized automatically when assigned."""
     width_segments: int
+    """Number of segments along the width. For handles, synchronized automatically when assigned."""
     height_segments: int
+    """Number of segments along the height. For handles, synchronized automatically when assigned."""
     plane: Literal["xz", "xy", "yx", "yz", "zx", "zy"]
+    """The plane in which the grid is oriented. For handles, synchronized automatically when assigned."""
     cell_color: int
+    """Color of the grid cells as an RGB integer. For handles, synchronized automatically when assigned."""
     cell_thickness: float
+    """Thickness of the grid lines. For handles, synchronized automatically when assigned."""
     cell_size: float
+    """Size of each cell in the grid. For handles, synchronized automatically when assigned."""
     section_color: int
+    """Color of the grid sections as an RGB integer. For handles, synchronized automatically when assigned."""
     section_thickness: float
+    """Thickness of the section lines. For handles, synchronized automatically when assigned."""
     section_size: float
+    """Size of each section in the grid. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -259,6 +286,7 @@ class LabelMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class LabelProps:
     text: str
+    """Text content of the label. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -272,7 +300,9 @@ class Gui3DMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class Gui3DProps:
     order: float
+    """Order value for arranging GUI elements. For handles, synchronized automatically when assigned."""
     container_id: str
+    """Identifier for the container. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -291,9 +321,13 @@ class PointCloudMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class PointCloudProps:
     points: onpt.NDArray[onp.float32]
+    """Location of points. Should have shape (N, 3). For handles, synchronized automatically when assigned."""
     colors: onpt.NDArray[onp.uint8]
+    """Colors of points. Should have shape (N, 3) or (3,). For handles, synchronized automatically when assigned."""
     point_size: float
+    """Size of each point. For handles, synchronized automatically when assigned."""
     point_ball_norm: float
+    """Norm value determining the shape of each point. For handles, synchronized automatically when assigned."""
 
     def __post_init__(self):
         # Check shapes.
@@ -318,14 +352,23 @@ class MeshMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class MeshProps:
     vertices: onpt.NDArray[onp.float32]
+    """A numpy array of vertex positions. Should have shape (V, 3). For handles, synchronized automatically when assigned."""
     faces: onpt.NDArray[onp.uint32]
+    """A numpy array of faces, where each face is represented by indices of vertices. Should have shape (F, 3). For handles, synchronized automatically when assigned."""
     color: Optional[int]
+    """Color of the mesh as an RGB integer. For handles, synchronized automatically when assigned."""
     vertex_colors: Optional[onpt.NDArray[onp.uint8]]
+    """Optional array of vertex colors. For handles, synchronized automatically when assigned."""
     wireframe: bool
+    """Boolean indicating if the mesh should be rendered as a wireframe. For handles, synchronized automatically when assigned."""
     opacity: Optional[float]
+    """Opacity of the mesh. None means opaque. For handles, synchronized automatically when assigned."""
     flat_shading: bool
+    """Whether to do flat shading. For handles, synchronized automatically when assigned."""
     side: Literal["front", "back", "double"]
+    """Side of the surface to render. For handles, synchronized automatically when assigned."""
     material: Literal["standard", "toon3", "toon5"]
+    """Material type of the mesh. For handles, synchronized automatically when assigned."""
 
     def __post_init__(self):
         # Check shapes.
@@ -348,9 +391,13 @@ class SkinnedMeshProps(MeshProps):
     Vertices are internally canonicalized to float32, faces to uint32."""
 
     bone_wxyzs: Tuple[Tuple[float, float, float, float], ...]
+    """Tuple of quaternions representing bone orientations. For handles, synchronized automatically when assigned."""
     bone_positions: Tuple[Tuple[float, float, float], ...]
+    """Tuple of positions representing bone positions. For handles, synchronized automatically when assigned."""
     skin_indices: onpt.NDArray[onp.uint16]
+    """Array of skin indices. Should have shape (V, 4). For handles, synchronized automatically when assigned."""
     skin_weights: onpt.NDArray[onp.float32]
+    """Array of skin weights. Should have shape (V, 4). For handles, synchronized automatically when assigned."""
 
     def __post_init__(self):
         # Check shapes.
@@ -405,21 +452,33 @@ class TransformControlsMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class TransformControlsProps:
     scale: float
+    """Scale of the transform controls. For handles, synchronized automatically when assigned."""
     line_width: float
+    """Width of the lines used in the gizmo. For handles, synchronized automatically when assigned."""
     fixed: bool
+    """Boolean indicating if the gizmo should be fixed in position. For handles, synchronized automatically when assigned."""
     auto_transform: bool
+    """Whether the transform should be applied automatically. For handles, synchronized automatically when assigned."""
     active_axes: Tuple[bool, bool, bool]
+    """Tuple of booleans indicating active axes. For handles, synchronized automatically when assigned."""
     disable_axes: bool
+    """Boolean to disable axes interaction. For handles, synchronized automatically when assigned."""
     disable_sliders: bool
+    """Boolean to disable slider interaction. For handles, synchronized automatically when assigned."""
     disable_rotations: bool
+    """Boolean to disable rotation interaction. For handles, synchronized automatically when assigned."""
     translation_limits: Tuple[
         Tuple[float, float], Tuple[float, float], Tuple[float, float]
     ]
+    """Limits for translation. For handles, synchronized automatically when assigned."""
     rotation_limits: Tuple[
         Tuple[float, float], Tuple[float, float], Tuple[float, float]
     ]
+    """Limits for rotation. For handles, synchronized automatically when assigned."""
     depth_test: bool
+    """Boolean indicating if depth testing should be used when rendering. For handles, synchronized automatically when assigned."""
     opacity: float
+    """Opacity of the gizmo. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -501,9 +560,13 @@ class ImageMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class ImageProps:
     media_type: Literal["image/jpeg", "image/png"]
+    """Format of the provided image ('image/jpeg' or 'image/png'). For handles, synchronized automatically when assigned."""
     data: bytes
+    """Binary data of the image. For handles, synchronized automatically when assigned."""
     render_width: float
+    """Width at which the image should be rendered in the scene. For handles, synchronized automatically when assigned."""
     render_height: float
+    """Height at which the image should be rendered in the scene. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -817,12 +880,19 @@ class CatmullRomSplineMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class CatmullRomSplineProps:
     positions: Tuple[Tuple[float, float, float], ...]
+    """A tuple of 3D positions (x, y, z) defining the spline's path. For handles, synchronized automatically when assigned."""
     curve_type: Literal["centripetal", "chordal", "catmullrom"]
+    """Type of the curve ('centripetal', 'chordal', 'catmullrom'). For handles, synchronized automatically when assigned."""
     tension: float
+    """Tension of the curve. Affects the tightness of the curve. For handles, synchronized automatically when assigned."""
     closed: bool
+    """Boolean indicating if the spline is closed (forms a loop). For handles, synchronized automatically when assigned."""
     line_width: float
+    """Width of the spline line. For handles, synchronized automatically when assigned."""
     color: int
+    """Color of the spline as an RGB integer. For handles, synchronized automatically when assigned."""
     segments: Optional[int]
+    """Number of segments to divide the spline into. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -836,10 +906,15 @@ class CubicBezierSplineMessage(Message, tag="SceneNodeMessage"):
 @dataclasses.dataclass
 class CubicBezierSplineProps:
     positions: Tuple[Tuple[float, float, float], ...]
+    """A tuple of 3D positions (x, y, z) defining the spline's key points. For handles, synchronized automatically when assigned."""
     control_points: Tuple[Tuple[float, float, float], ...]
+    """A tuple of control points for Bezier curve shaping. For handles, synchronized automatically when assigned."""
     line_width: float
+    """Width of the spline line. For handles, synchronized automatically when assigned."""
     color: int
+    """Color of the spline as an RGB integer. For handles, synchronized automatically when assigned."""
     segments: Optional[int]
+    """Number of segments to divide the spline into. For handles, synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -864,7 +939,8 @@ class GaussianSplatsProps:
     - cov3 (f16), cov4 (f16)
     - cov5 (f16), cov6 (f16)
     - rgba (int32)
-    Where cov1-6 are the upper triangular elements of the covariance matrix."""
+
+    Where cov1-6 are the terms of the upper-triangular Cholesky factorization."""
 
 
 @dataclasses.dataclass

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -935,12 +935,13 @@ class GaussianSplatsProps:
     - y as f32
     - z as f32
     - (unused)
-    - cov1 (f16), cov2 (f16)
-    - cov3 (f16), cov4 (f16)
-    - cov5 (f16), cov6 (f16)
+    - chol1 (f16), chol2 (f16)
+    - chol3 (f16), chol4 (f16)
+    - chol5 (f16), chol6 (f16)
     - rgba (int32)
 
-    Where cov1-6 are the terms of the upper-triangular Cholesky factorization."""
+    Where chol1-6 are the terms of the upper-triangular Cholesky
+    factor of covariance matrices."""
 
 
 @dataclasses.dataclass

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -19,6 +19,7 @@ from ._scene_handles import (
     FrameHandle,
     GaussianSplatHandle,
     GlbHandle,
+    GridHandle,
     Gui3dContainerHandle,
     ImageHandle,
     LabelHandle,
@@ -29,6 +30,8 @@ from ._scene_handles import (
     SceneNodeHandle,
     SceneNodePointerEvent,
     ScenePointerEvent,
+    SplineCatmullRomHandle,
+    SplineCubicBezierHandle,
     TransformControlsHandle,
     _TransformControlsState,
     colors_to_uint8,
@@ -282,7 +285,7 @@ class SceneApi:
         wxyz: tuple[float, float, float, float] | onp.ndarray = (1.0, 0.0, 0.0, 0.0),
         position: tuple[float, float, float] | onp.ndarray = (0.0, 0.0, 0.0),
         visible: bool = True,
-    ) -> SceneNodeHandle:
+    ) -> SplineCatmullRomHandle:
         """Add a spline to the scene using Catmull-Rom interpolation.
 
         This method creates a spline based on a set of positions and interpolates
@@ -322,20 +325,22 @@ class SceneApi:
                 segments=segments,
             ),
         )
-        return SceneNodeHandle._make(self, message, name, wxyz, position, visible)
+        return SplineCatmullRomHandle._make(
+            self, message, name, wxyz, position, visible
+        )
 
     def add_spline_cubic_bezier(
         self,
         name: str,
         positions: tuple[tuple[float, float, float], ...] | onp.ndarray,
         control_points: tuple[tuple[float, float, float], ...] | onp.ndarray,
-        line_width: float = 1,
+        line_width: float = 1.0,
         color: RgbTupleOrArray = (20, 20, 20),
         segments: int | None = None,
         wxyz: tuple[float, float, float, float] | onp.ndarray = (1.0, 0.0, 0.0, 0.0),
         position: tuple[float, float, float] | onp.ndarray = (0.0, 0.0, 0.0),
         visible: bool = True,
-    ) -> SceneNodeHandle:
+    ) -> SplineCubicBezierHandle:
         """Add a spline to the scene using Cubic Bezier interpolation.
 
         This method allows for the creation of a cubic Bezier spline based on given
@@ -378,7 +383,9 @@ class SceneApi:
                 segments=segments,
             ),
         )
-        return SceneNodeHandle._make(self, message, name, wxyz, position, visible)
+        return SplineCubicBezierHandle._make(
+            self, message, name, wxyz, position, visible
+        )
 
     def add_camera_frustum(
         self,
@@ -565,7 +572,7 @@ class SceneApi:
         wxyz: tuple[float, float, float, float] | onp.ndarray = (1.0, 0.0, 0.0, 0.0),
         position: tuple[float, float, float] | onp.ndarray = (0.0, 0.0, 0.0),
         visible: bool = True,
-    ) -> SceneNodeHandle:
+    ) -> GridHandle:
         """Add a 2D grid to the scene.
 
         This can be useful as a size, orientation, or ground plane reference.
@@ -606,7 +613,7 @@ class SceneApi:
                 section_size=section_size,
             ),
         )
-        return SceneNodeHandle._make(self, message, name, wxyz, position, visible)
+        return GridHandle._make(self, message, name, wxyz, position, visible)
 
     def add_label(
         self,

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -461,6 +461,7 @@ class Gui3dContainerHandle(
         self._container_id = container_id
         self._container_id_restore = None
         self._children = {}
+        self._gui_api._container_handle_from_id[self._container_id] = self
 
     def __enter__(self) -> Gui3dContainerHandle:
         self._container_id_restore = self._gui_api._get_container_id()
@@ -472,9 +473,6 @@ class Gui3dContainerHandle(
         assert self._container_id_restore is not None
         self._gui_api._set_container_id(self._container_id_restore)
         self._container_id_restore = None
-
-    def __post_init__(self) -> None:
-        self._gui_api._container_handle_from_id[self._container_id] = self
 
     def remove(self) -> None:
         """Permanently remove this GUI container from the visualizer."""

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -389,6 +389,33 @@ class MeshSkinnedBoneHandle:
         )
 
 
+class GridHandle(
+    SceneNodeHandle,
+    _messages.GridProps,
+    _OverridablePropApi,
+    PropClass=_messages.GridProps,
+):
+    """Handle for grid objects."""
+
+
+class SplineCatmullRomHandle(
+    SceneNodeHandle,
+    _messages.CatmullRomSplineProps,
+    _OverridablePropApi,
+    PropClass=_messages.CatmullRomSplineProps,
+):
+    """Handle for Catmull-Rom splines."""
+
+
+class SplineCubicBezierHandle(
+    SceneNodeHandle,
+    _messages.CubicBezierSplineProps,
+    _OverridablePropApi,
+    PropClass=_messages.CubicBezierSplineProps,
+):
+    """Handle for cubic Bezier splines."""
+
+
 class GlbHandle(
     _ClickableSceneNodeHandle,
     _messages.GlbProps,

--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -72,7 +72,7 @@ export type ViewerContextContents = {
     [name: string]:
       | undefined
       | {
-          poseUpdateState?: "updated" | "needsUpdate" | "waitForMakeObject";
+          poseUpdateState?: "updated" | "needsUpdate";
           wxyz?: [number, number, number, number];
           position?: [number, number, number];
           visibility?: boolean; // Visibility state from the server.
@@ -470,7 +470,7 @@ function AdaptiveDpr() {
       iterations={5}
       step={0.1}
       bounds={(refreshrate) => {
-        const max = Math.min(refreshrate * 0.9, 85);
+        const max = Math.min(refreshrate * 0.75, 85);
         const min = Math.max(max * 0.5, 38);
         return [min, max];
       }}

--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -72,7 +72,7 @@ export type ViewerContextContents = {
     [name: string]:
       | undefined
       | {
-          poseUpdateState?: "updated" | "needsUpdate";
+          poseUpdateState?: "updated" | "needsUpdate" | "waitForMakeObject";
           wxyz?: [number, number, number, number];
           position?: [number, number, number];
           visibility?: boolean; // Visibility state from the server.

--- a/src/viser/client/src/ControlPanel/GuiState.tsx
+++ b/src/viser/client/src/ControlPanel/GuiState.tsx
@@ -7,10 +7,6 @@ import { immer } from "zustand/middleware/immer";
 
 export type GuiConfig = Messages.GuiAddComponentMessage;
 
-export function isGuiConfig(message: Messages.Message): message is GuiConfig {
-  return message.type.startsWith("GuiAdd");
-}
-
 interface GuiState {
   theme: Messages.ThemeConfigurationMessage;
   label: string;

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -306,6 +306,9 @@ function useMessageHandler() {
         removeSceneNode(message.name);
         const attrs = viewer.nodeAttributesFromName.current;
         delete attrs[message.name];
+
+        if (viewer.skinnedMeshState.current[message.name] !== undefined)
+          delete viewer.skinnedMeshState.current[message.name];
         return;
       }
       // Set the clickability of a particular scene node.

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -64,7 +64,6 @@ function useMessageHandler() {
 
   // Return message handler.
   return (message: Message) => {
-    console.log(message.type);
     if (isGuiConfig(message)) {
       addGui(message);
       return;
@@ -158,13 +157,13 @@ function useMessageHandler() {
 
       // Set the bone poses.
       case "SetBoneOrientationMessage": {
-        const bonePoses = viewer.skinnedMeshState.current;
-        bonePoses[message.name].poses[message.bone_index].wxyz = message.wxyz;
+        const state = viewer.skinnedMeshState.current;
+        state[message.name].poses[message.bone_index].wxyz = message.wxyz;
         break;
       }
       case "SetBonePositionMessage": {
-        const bonePoses = viewer.skinnedMeshState.current;
-        bonePoses[message.name].poses[message.bone_index].position =
+        const state = viewer.skinnedMeshState.current;
+        state[message.name].poses[message.bone_index].position =
           message.position;
         break;
       }
@@ -345,11 +344,28 @@ function useMessageHandler() {
         return;
       }
 
+      // Initialize skinned mesh state.
+      case "SkinnedMeshMessage": {
+        viewer.skinnedMeshState.current[message.name] = {
+          initialized: false,
+          poses: [],
+        };
+        for (let i = 0; i < message.bone_wxyzs!.length; i++) {
+          const wxyz = message.bone_wxyzs[i];
+          const position = message.bone_positions[i];
+          viewer.skinnedMeshState.current[message.name].poses.push({
+            wxyz: wxyz,
+            position: position,
+          });
+        }
+        addSceneNodeMakeParents(message);
+        return;
+      }
+
       case "FrameMessage":
       case "BatchedAxesMessage":
       case "GridMessage":
       case "PointCloudMessage":
-      case "SkinnedMeshMessage":
       case "MeshMessage":
       case "CameraFrustumMessage":
       case "TransformControlsMessage":

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -1,5 +1,3 @@
-import { CatmullRomLine, CubicBezierLine, Grid, Html } from "@react-three/drei";
-import { useContextBridge } from "its-fine";
 import { notifications } from "@mantine/notifications";
 
 import React, { useContext } from "react";
@@ -7,49 +5,23 @@ import * as THREE from "three";
 import { TextureLoader } from "three";
 
 import { ViewerContext } from "./App";
-import { SceneNode } from "./SceneTree";
-import {
-  CameraFrustum,
-  CoordinateFrame,
-  InstancedAxes,
-  GlbAsset,
-  OutlinesIfHovered,
-  PointCloud,
-} from "./ThreeAssets";
 import {
   FileTransferPart,
   FileTransferStart,
   Message,
+  SceneNodeMessage,
 } from "./WebsocketMessages";
-import { PivotControls } from "@react-three/drei";
-import { isTexture, makeThrottledMessageSender } from "./WebsocketFunctions";
+import { isTexture } from "./WebsocketFunctions";
 import { isGuiConfig } from "./ControlPanel/GuiState";
 import { useFrame } from "@react-three/fiber";
-import GeneratedGuiContainer from "./ControlPanel/Generated";
-import { Paper, Progress } from "@mantine/core";
+import { Progress } from "@mantine/core";
 import { IconCheck } from "@tabler/icons-react";
 import { computeT_threeworld_world } from "./WorldTransformUtils";
-import { SplatObject } from "./Splatting/GaussianSplats";
-
-/** Convert raw RGB color buffers to linear color buffers. **/
-function threeColorBufferFromUint8Buffer(colors: ArrayBuffer) {
-  return new THREE.Float32BufferAttribute(
-    new Float32Array(new Uint8Array(colors)).map((value) => {
-      value = value / 255.0;
-      if (value <= 0.04045) {
-        return value / 12.92;
-      } else {
-        return Math.pow((value + 0.055) / 1.055, 2.4);
-      }
-    }),
-    3,
-  );
-}
+import { rootNodeTemplate } from "./SceneTreeState";
 
 /** Returns a handler for all incoming messages. */
 function useMessageHandler() {
   const viewer = useContext(ViewerContext)!;
-  const ContextBridge = useContextBridge();
 
   // We could reduce the redundancy here if we wanted to.
   // https://github.com/nerfstudio-project/viser/issues/39
@@ -69,33 +41,30 @@ function useMessageHandler() {
 
   // Same as addSceneNode, but make a parent in the form of a dummy coordinate
   // frame if it doesn't exist yet.
-  function addSceneNodeMakeParents(node: SceneNode<any>) {
+  function addSceneNodeMakeParents(message: SceneNodeMessage) {
     // Make sure scene node is in attributes.
     const attrs = viewer.nodeAttributesFromName.current;
-    attrs[node.name] = {
-      overrideVisibility: attrs[node.name]?.overrideVisibility,
+    attrs[message.name] = {
+      overrideVisibility: attrs[message.name]?.overrideVisibility,
     };
-
-    // Don't update the pose of the object until we've made a new one!
-    attrs[node.name]!.poseUpdateState = "waitForMakeObject";
 
     // Make sure parents exists.
     const nodeFromName = viewer.useSceneTree.getState().nodeFromName;
-    const parentName = node.name.split("/").slice(0, -1).join("/");
+    const parentName = message.name.split("/").slice(0, -1).join("/");
     if (!(parentName in nodeFromName)) {
-      addSceneNodeMakeParents(
-        new SceneNode<THREE.Group>(parentName, (ref) => (
-          <CoordinateFrame ref={ref} showAxes={false} />
-        )),
-      );
+      addSceneNodeMakeParents({
+        ...rootNodeTemplate.message,
+        name: parentName,
+      });
     }
-    addSceneNode(node);
+    addSceneNode(message);
   }
 
   const fileDownloadHandler = useFileDownloadHandler();
 
   // Return message handler.
   return (message: Message) => {
+    console.log(message.type);
     if (isGuiConfig(message)) {
       addGui(message);
       return;
@@ -177,142 +146,6 @@ function useMessageHandler() {
         return;
       }
 
-      // Add a coordinate frame.
-      case "FrameMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(message.name, (ref) => (
-            <CoordinateFrame
-              ref={ref}
-              showAxes={message.show_axes}
-              axesLength={message.axes_length}
-              axesRadius={message.axes_radius}
-              originRadius={message.origin_radius}
-            />
-          )),
-        );
-        return;
-      }
-
-      // Add axes to visualize.
-      case "BatchedAxesMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(
-            message.name,
-            (ref) => (
-              // Minor naming discrepancy: I think "batched" will be clearer to
-              // folks on the Python side, but instanced is somewhat more
-              // precise.
-              <InstancedAxes
-                ref={ref}
-                wxyzsBatched={
-                  new Float32Array(
-                    message.wxyzs_batched.buffer.slice(
-                      message.wxyzs_batched.byteOffset,
-                      message.wxyzs_batched.byteOffset +
-                        message.wxyzs_batched.byteLength,
-                    ),
-                  )
-                }
-                positionsBatched={
-                  new Float32Array(
-                    message.positions_batched.buffer.slice(
-                      message.positions_batched.byteOffset,
-                      message.positions_batched.byteOffset +
-                        message.positions_batched.byteLength,
-                    ),
-                  )
-                }
-                axes_length={message.axes_length}
-                axes_radius={message.axes_radius}
-              />
-            ),
-            undefined,
-            undefined,
-            undefined,
-            // Compute click instance index from instance ID. Each visualized
-            // frame has 1 instance for each of 3 line segments.
-            (instanceId) => Math.floor(instanceId! / 3),
-          ),
-        );
-        return;
-      }
-
-      case "GridMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(message.name, (ref) => (
-            <group ref={ref}>
-              <Grid
-                args={[
-                  message.width,
-                  message.height,
-                  message.width_segments,
-                  message.height_segments,
-                ]}
-                side={THREE.DoubleSide}
-                cellColor={message.cell_color}
-                cellThickness={message.cell_thickness}
-                cellSize={message.cell_size}
-                sectionColor={message.section_color}
-                sectionThickness={message.section_thickness}
-                sectionSize={message.section_size}
-                rotation={
-                  // There's redundancy here when we set the side to
-                  // THREE.DoubleSide, where xy and yx should be the same.
-                  //
-                  // But it makes sense to keep this parameterization because
-                  // specifying planes by xy seems more natural than the normal
-                  // direction (z, +z, or -z), and it opens the possibility of
-                  // rendering only FrontSide or BackSide grids in the future.
-                  //
-                  // If we add support for FrontSide or BackSide, we should
-                  // double-check that the normal directions from each of these
-                  // rotations match the right-hand rule!
-                  message.plane == "xz"
-                    ? new THREE.Euler(0.0, 0.0, 0.0)
-                    : message.plane == "xy"
-                    ? new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)
-                    : message.plane == "yx"
-                    ? new THREE.Euler(0.0, Math.PI / 2.0, Math.PI / 2.0)
-                    : message.plane == "yz"
-                    ? new THREE.Euler(0.0, 0.0, Math.PI / 2.0)
-                    : message.plane == "zx"
-                    ? new THREE.Euler(0.0, Math.PI / 2.0, 0.0)
-                    : message.plane == "zy"
-                    ? new THREE.Euler(-Math.PI / 2.0, 0.0, -Math.PI / 2.0)
-                    : undefined
-                }
-              />
-            </group>
-          )),
-        );
-        return;
-      }
-
-      // Add a point cloud.
-      case "PointCloudMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Points>(message.name, (ref) => (
-            <PointCloud
-              ref={ref}
-              pointSize={message.point_size}
-              pointBallNorm={message.point_ball_norm}
-              points={
-                new Float32Array(
-                  message.points.buffer.slice(
-                    message.points.byteOffset,
-                    message.points.byteOffset + message.points.byteLength,
-                  ),
-                )
-              }
-              colors={new Float32Array(message.colors).map(
-                (val) => val / 255.0,
-              )}
-            />
-          )),
-        );
-        return;
-      }
-
       case "GuiModalMessage": {
         addModal(message);
         return;
@@ -323,240 +156,6 @@ function useMessageHandler() {
         return;
       }
 
-      // Add mesh
-      case "SkinnedMeshMessage":
-      case "MeshMessage": {
-        const geometry = new THREE.BufferGeometry();
-
-        const generateGradientMap = (shades: 3 | 5) => {
-          const texture = new THREE.DataTexture(
-            Uint8Array.from(
-              shades == 3
-                ? [0, 0, 0, 255, 128, 128, 128, 255, 255, 255, 255, 255]
-                : [
-                    0, 0, 0, 255, 64, 64, 64, 255, 128, 128, 128, 255, 192, 192,
-                    192, 255, 255, 255, 255, 255,
-                  ],
-            ),
-            shades,
-            1,
-            THREE.RGBAFormat,
-          );
-
-          texture.needsUpdate = true;
-          return texture;
-        };
-        const standardArgs = {
-          color: message.color ?? undefined,
-          vertexColors: message.vertex_colors !== null,
-          wireframe: message.wireframe,
-          transparent: message.opacity !== null,
-          opacity: message.opacity ?? 1.0,
-          // Flat shading only makes sense for non-wireframe materials.
-          flatShading: message.flat_shading && !message.wireframe,
-          side: {
-            front: THREE.FrontSide,
-            back: THREE.BackSide,
-            double: THREE.DoubleSide,
-          }[message.side],
-        };
-        const assertUnreachable = (x: never): never => {
-          throw new Error(`Should never get here! ${x}`);
-        };
-        const material =
-          message.material == "standard" || message.wireframe
-            ? new THREE.MeshStandardMaterial(standardArgs)
-            : message.material == "toon3"
-            ? new THREE.MeshToonMaterial({
-                gradientMap: generateGradientMap(3),
-                ...standardArgs,
-              })
-            : message.material == "toon5"
-            ? new THREE.MeshToonMaterial({
-                gradientMap: generateGradientMap(5),
-                ...standardArgs,
-              })
-            : assertUnreachable(message.material);
-        geometry.setAttribute(
-          "position",
-          new THREE.Float32BufferAttribute(
-            new Float32Array(
-              message.vertices.buffer.slice(
-                message.vertices.byteOffset,
-                message.vertices.byteOffset + message.vertices.byteLength,
-              ),
-            ),
-            3,
-          ),
-        );
-        if (message.vertex_colors !== null) {
-          geometry.setAttribute(
-            "color",
-            threeColorBufferFromUint8Buffer(message.vertex_colors),
-          );
-        }
-
-        geometry.setIndex(
-          new THREE.Uint32BufferAttribute(
-            new Uint32Array(
-              message.faces.buffer.slice(
-                message.faces.byteOffset,
-                message.faces.byteOffset + message.faces.byteLength,
-              ),
-            ),
-            1,
-          ),
-        );
-        geometry.computeVertexNormals();
-        geometry.computeBoundingSphere();
-        const cleanupMesh = () => {
-          // TODO: we can switch to the react-three-fiber <bufferGeometry />,
-          // <meshStandardMaterial />, etc components to avoid manual
-          // disposal.
-          geometry.dispose();
-          material.dispose();
-        };
-        if (message.type === "MeshMessage")
-          // Normal mesh.
-          addSceneNodeMakeParents(
-            new SceneNode<THREE.Mesh>(
-              message.name,
-              (ref) => {
-                return (
-                  <mesh ref={ref} geometry={geometry} material={material}>
-                    <OutlinesIfHovered alwaysMounted />
-                  </mesh>
-                );
-              },
-              cleanupMesh,
-            ),
-          );
-        else if (message.type === "SkinnedMeshMessage") {
-          // Skinned mesh.
-          const bones: THREE.Bone[] = [];
-          for (let i = 0; i < message.bone_wxyzs!.length; i++) {
-            bones.push(new THREE.Bone());
-          }
-
-          const xyzw_quat = new THREE.Quaternion();
-          const boneInverses: THREE.Matrix4[] = [];
-          viewer.skinnedMeshState.current[message.name] = {
-            initialized: false,
-            poses: [],
-          };
-          bones.forEach((bone, i) => {
-            const wxyz = message.bone_wxyzs[i];
-            const position = message.bone_positions[i];
-            xyzw_quat.set(wxyz[1], wxyz[2], wxyz[3], wxyz[0]);
-
-            const boneInverse = new THREE.Matrix4();
-            boneInverse.makeRotationFromQuaternion(xyzw_quat);
-            boneInverse.setPosition(position[0], position[1], position[2]);
-            boneInverse.invert();
-            boneInverses.push(boneInverse);
-
-            bone.quaternion.copy(xyzw_quat);
-            bone.position.set(position[0], position[1], position[2]);
-            bone.matrixAutoUpdate = false;
-            bone.matrixWorldAutoUpdate = false;
-
-            viewer.skinnedMeshState.current[message.name].poses.push({
-              wxyz: wxyz,
-              position: position,
-            });
-          });
-          const skeleton = new THREE.Skeleton(bones, boneInverses);
-
-          geometry.setAttribute(
-            "skinIndex",
-            new THREE.Uint16BufferAttribute(
-              new Uint16Array(
-                message.skin_indices.buffer.slice(
-                  message.skin_indices.byteOffset,
-                  message.skin_indices.byteOffset +
-                    message.skin_indices.byteLength,
-                ),
-              ),
-              4,
-            ),
-          );
-          geometry.setAttribute(
-            "skinWeight",
-            new THREE.Float32BufferAttribute(
-              new Float32Array(
-                message.skin_weights!.buffer.slice(
-                  message.skin_weights!.byteOffset,
-                  message.skin_weights!.byteOffset +
-                    message.skin_weights!.byteLength,
-                ),
-              ),
-              4,
-            ),
-          );
-
-          addSceneNodeMakeParents(
-            new SceneNode<THREE.SkinnedMesh>(
-              message.name,
-              (ref) => {
-                return (
-                  <skinnedMesh
-                    ref={ref}
-                    geometry={geometry}
-                    material={material}
-                    skeleton={skeleton}
-                    // TODO: leaving culling on (default) sometimes causes the
-                    // mesh to randomly disappear, as of r3f==8.16.2.
-                    //
-                    // Probably this is because we don't update the bounding
-                    // sphere after the bone transforms change.
-                    frustumCulled={false}
-                  >
-                    <OutlinesIfHovered alwaysMounted />
-                  </skinnedMesh>
-                );
-              },
-              () => {
-                delete viewer.skinnedMeshState.current[message.name];
-                skeleton.dispose();
-                cleanupMesh();
-              },
-              false,
-              // everyFrameCallback: update bone transforms.
-              () => {
-                const parentNode = viewer.nodeRefFromName.current[message.name];
-                if (parentNode === undefined) return;
-
-                const state = viewer.skinnedMeshState.current[message.name];
-                bones.forEach((bone, i) => {
-                  if (!state.initialized) {
-                    parentNode.add(bone);
-                  }
-                  const wxyz = state.initialized
-                    ? state.poses[i].wxyz
-                    : message.bone_wxyzs[i];
-                  const position = state.initialized
-                    ? state.poses[i].position
-                    : message.bone_positions[i];
-
-                  xyzw_quat.set(wxyz[1], wxyz[2], wxyz[3], wxyz[0]);
-                  bone.matrix.makeRotationFromQuaternion(xyzw_quat);
-                  bone.matrix.setPosition(
-                    position[0],
-                    position[1],
-                    position[2],
-                  );
-                  bone.updateMatrixWorld();
-                });
-
-                if (!state.initialized) {
-                  state.initialized = true;
-                }
-              },
-            ),
-          );
-        }
-        return;
-      }
       // Set the bone poses.
       case "SetBoneOrientationMessage": {
         const bonePoses = viewer.skinnedMeshState.current;
@@ -568,93 +167,6 @@ function useMessageHandler() {
         bonePoses[message.name].poses[message.bone_index].position =
           message.position;
         break;
-      }
-      // Add a camera frustum.
-      case "CameraFrustumMessage": {
-        let texture = undefined;
-        if (
-          message.image_media_type !== null &&
-          message.image_binary !== null
-        ) {
-          const image_url = URL.createObjectURL(
-            new Blob([message.image_binary]),
-          );
-          texture = new TextureLoader().load(image_url, () =>
-            URL.revokeObjectURL(image_url),
-          );
-        }
-
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(
-            message.name,
-            (ref) => (
-              <CameraFrustum
-                ref={ref}
-                fov={message.fov}
-                aspect={message.aspect}
-                scale={message.scale}
-                color={message.color}
-                image={texture}
-              />
-            ),
-            () => texture?.dispose(),
-          ),
-        );
-        return;
-      }
-      case "TransformControlsMessage": {
-        const name = message.name;
-        const sendDragMessage = makeThrottledMessageSender(viewer, 50);
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(
-            message.name,
-            (ref) => (
-              <group onClick={(e) => e.stopPropagation()}>
-                <PivotControls
-                  ref={ref}
-                  scale={message.scale}
-                  lineWidth={message.line_width}
-                  fixed={message.fixed}
-                  autoTransform={message.auto_transform}
-                  activeAxes={message.active_axes}
-                  disableAxes={message.disable_axes}
-                  disableSliders={message.disable_sliders}
-                  disableRotations={message.disable_rotations}
-                  disableScaling={true}
-                  translationLimits={message.translation_limits}
-                  rotationLimits={message.rotation_limits}
-                  depthTest={message.depth_test}
-                  opacity={message.opacity}
-                  onDrag={(l) => {
-                    const attrs = viewer.nodeAttributesFromName.current;
-                    if (attrs[message.name] === undefined) {
-                      attrs[message.name] = {};
-                    }
-
-                    const wxyz = new THREE.Quaternion();
-                    wxyz.setFromRotationMatrix(l);
-                    const position = new THREE.Vector3().setFromMatrixPosition(
-                      l,
-                    );
-
-                    const nodeAttributes = attrs[message.name]!;
-                    nodeAttributes.wxyz = [wxyz.w, wxyz.x, wxyz.y, wxyz.z];
-                    nodeAttributes.position = position.toArray();
-                    sendDragMessage({
-                      type: "TransformControlsUpdateMessage",
-                      name: name,
-                      wxyz: nodeAttributes.wxyz,
-                      position: nodeAttributes.position,
-                    });
-                  }}
-                />
-              </group>
-            ),
-            undefined,
-            true, // unmountWhenInvisible
-          ),
-        );
-        return;
       }
       case "SetCameraLookAtMessage": {
         const cameraControls = viewer.cameraControlRef.current!;
@@ -734,16 +246,14 @@ function useMessageHandler() {
         const attr = viewer.nodeAttributesFromName.current;
         if (attr[message.name] === undefined) attr[message.name] = {};
         attr[message.name]!.wxyz = message.wxyz;
-        if (attr[message.name]!.poseUpdateState == "updated")
-          attr[message.name]!.poseUpdateState = "needsUpdate";
+        attr[message.name]!.poseUpdateState = "needsUpdate";
         break;
       }
       case "SetPositionMessage": {
         const attr = viewer.nodeAttributesFromName.current;
         if (attr[message.name] === undefined) attr[message.name] = {};
         attr[message.name]!.position = message.position;
-        if (attr[message.name]!.poseUpdateState == "updated")
-          attr[message.name]!.poseUpdateState = "needsUpdate";
+        attr[message.name]!.poseUpdateState = "needsUpdate";
         break;
       }
       case "SetSceneNodeVisibilityMessage": {
@@ -791,134 +301,6 @@ function useMessageHandler() {
         }
         return;
       }
-      // Add a 2D label.
-      case "LabelMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(
-            message.name,
-            (ref) => {
-              // We wrap with <group /> because Html doesn't implement THREE.Object3D.
-              return (
-                <group ref={ref}>
-                  <Html>
-                    <div
-                      style={{
-                        width: "10em",
-                        fontSize: "0.8em",
-                        transform: "translateX(0.1em) translateY(0.5em)",
-                      }}
-                    >
-                      <span
-                        style={{
-                          background: "#fff",
-                          border: "1px solid #777",
-                          borderRadius: "0.2em",
-                          color: "#333",
-                          padding: "0.2em",
-                        }}
-                      >
-                        {message.text}
-                      </span>
-                    </div>
-                  </Html>
-                </group>
-              );
-            },
-            undefined,
-            true,
-          ),
-        );
-        return;
-      }
-      case "Gui3DMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(
-            message.name,
-            (ref) => {
-              // We wrap with <group /> because Html doesn't implement
-              // THREE.Object3D. The initial position is intended to be
-              // off-screen; it will be overwritten with the actual position
-              // after the component is mounted.
-              return (
-                <group ref={ref} position={new THREE.Vector3(1e8, 1e8, 1e8)}>
-                  <Html>
-                    <ContextBridge>
-                      <Paper
-                        style={{
-                          width: "18em",
-                          fontSize: "0.875em",
-                          marginLeft: "0.5em",
-                          marginTop: "0.5em",
-                        }}
-                        shadow="0 0 0.8em 0 rgba(0,0,0,0.1)"
-                        pb="0.25em"
-                        onPointerDown={(evt) => {
-                          evt.stopPropagation();
-                        }}
-                      >
-                        <ViewerContext.Provider value={viewer}>
-                          <GeneratedGuiContainer
-                            containerId={message.container_id}
-                          />
-                        </ViewerContext.Provider>
-                      </Paper>
-                    </ContextBridge>
-                  </Html>
-                </group>
-              );
-            },
-            undefined,
-            true,
-          ),
-        );
-        return;
-      }
-      // Add an image.
-      case "ImageMessage": {
-        // This current implementation may flicker when the image is updated,
-        // because the texture is not necessarily done loading before the
-        // component is mounted. We could fix this by passing an `onLoad`
-        // callback into `TextureLoader`, but this would require work because
-        // `addSceneNodeMakeParents` needs to be called immediately: it
-        // overwrites position/wxyz attributes, and we don't want this to
-        // happen after later messages are received.
-        const image_url = URL.createObjectURL(
-          new Blob([message.data], {
-            type: message.media_type,
-          }),
-        );
-        const texture = new TextureLoader().load(
-          image_url,
-          () => URL.revokeObjectURL(image_url), // Revoke URL on load.
-        );
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(
-            message.name,
-            (ref) => {
-              return (
-                <group ref={ref}>
-                  <mesh rotation={new THREE.Euler(Math.PI, 0.0, 0.0)}>
-                    <OutlinesIfHovered />
-                    <planeGeometry
-                      attach="geometry"
-                      args={[message.render_width, message.render_height]}
-                    />
-                    <meshBasicMaterial
-                      attach="material"
-                      transparent={true}
-                      side={THREE.DoubleSide}
-                      map={texture}
-                      toneMapped={false}
-                    />
-                  </mesh>
-                </group>
-              );
-            },
-            () => texture.dispose(),
-          ),
-        );
-        return;
-      }
       // Remove a scene node and its children by name.
       case "RemoveSceneNodeMessage": {
         console.log("Removing scene node:", message.name);
@@ -962,84 +344,23 @@ function useMessageHandler() {
         removeGui(message.id);
         return;
       }
-      // Add a glTF/GLB asset.
-      case "GlbMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(message.name, (ref) => {
-            return (
-              <GlbAsset
-                ref={ref}
-                glb_data={new Uint8Array(message.glb_data)}
-                scale={message.scale}
-              />
-            );
-          }),
-        );
-        return;
-      }
-      case "CatmullRomSplineMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(message.name, (ref) => {
-            return (
-              <group ref={ref}>
-                <CatmullRomLine
-                  points={message.positions}
-                  closed={message.closed}
-                  curveType={message.curve_type}
-                  tension={message.tension}
-                  lineWidth={message.line_width}
-                  color={message.color}
-                  // Sketchy cast needed due to https://github.com/pmndrs/drei/issues/1476.
-                  segments={(message.segments ?? undefined) as undefined}
-                ></CatmullRomLine>
-              </group>
-            );
-          }),
-        );
-        return;
-      }
-      case "CubicBezierSplineMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(message.name, (ref) => {
-            return (
-              <group ref={ref}>
-                {[...Array(message.positions.length - 1).keys()].map((i) => (
-                  <CubicBezierLine
-                    key={i}
-                    start={message.positions[i]}
-                    end={message.positions[i + 1]}
-                    midA={message.control_points[2 * i]}
-                    midB={message.control_points[2 * i + 1]}
-                    lineWidth={message.line_width}
-                    color={message.color}
-                    // Sketchy cast needed due to https://github.com/pmndrs/drei/issues/1476.
-                    segments={(message.segments ?? undefined) as undefined}
-                  ></CubicBezierLine>
-                ))}
-              </group>
-            );
-          }),
-        );
-        return;
-      }
+
+      case "FrameMessage":
+      case "BatchedAxesMessage":
+      case "GridMessage":
+      case "PointCloudMessage":
+      case "SkinnedMeshMessage":
+      case "MeshMessage":
+      case "CameraFrustumMessage":
+      case "TransformControlsMessage":
+      case "LabelMessage":
+      case "Gui3DMessage":
+      case "ImageMessage":
+      case "GlbMessage":
+      case "CatmullRomSplineMessage":
+      case "CubicBezierSplineMessage":
       case "GaussianSplatsMessage": {
-        addSceneNodeMakeParents(
-          new SceneNode<THREE.Group>(message.name, (ref) => {
-            return (
-              <SplatObject
-                ref={ref}
-                buffer={
-                  new Uint32Array(
-                    message.buffer.buffer.slice(
-                      message.buffer.byteOffset,
-                      message.buffer.byteOffset + message.buffer.byteLength,
-                    ),
-                  )
-                }
-              />
-            );
-          }),
-        );
+        addSceneNodeMakeParents(message);
         return;
       }
       case "FileTransferStart":

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -28,13 +28,16 @@ import {
   PointCloud,
   ViserImage,
   ViserMesh,
-  rgbToInt,
 } from "./ThreeAssets";
 import { opencvXyFromPointerXy } from "./ClickUtils";
 import { SceneNodeMessage } from "./WebsocketMessages";
 import { SplatObject } from "./Splatting/GaussianSplats";
 import { Paper } from "@mantine/core";
 import GeneratedGuiContainer from "./ControlPanel/Generated";
+
+function rgbToInt(rgb: [number, number, number]): number {
+  return (rgb[0] << 16) | (rgb[1] << 8) | rgb[2];
+}
 
 /** Type corresponding to a zustand-style useSceneTree hook. */
 export type UseSceneTree = ReturnType<typeof useSceneTreeState>;

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -138,10 +138,10 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
         makeObject: (ref) => (
           <CoordinateFrame
             ref={ref}
-            showAxes={message.show_axes}
-            axesLength={message.axes_length}
-            axesRadius={message.axes_radius}
-            originRadius={message.origin_radius}
+            showAxes={message.props.show_axes}
+            axesLength={message.props.axes_length}
+            axesRadius={message.props.axes_radius}
+            originRadius={message.props.origin_radius}
           />
         ),
       };
@@ -158,24 +158,24 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
             ref={ref}
             wxyzsBatched={
               new Float32Array(
-                message.wxyzs_batched.buffer.slice(
-                  message.wxyzs_batched.byteOffset,
-                  message.wxyzs_batched.byteOffset +
-                    message.wxyzs_batched.byteLength,
+                message.props.wxyzs_batched.buffer.slice(
+                  message.props.wxyzs_batched.byteOffset,
+                  message.props.wxyzs_batched.byteOffset +
+                    message.props.wxyzs_batched.byteLength,
                 ),
               )
             }
             positionsBatched={
               new Float32Array(
-                message.positions_batched.buffer.slice(
-                  message.positions_batched.byteOffset,
-                  message.positions_batched.byteOffset +
-                    message.positions_batched.byteLength,
+                message.props.positions_batched.buffer.slice(
+                  message.props.positions_batched.byteOffset,
+                  message.props.positions_batched.byteOffset +
+                    message.props.positions_batched.byteLength,
                 ),
               )
             }
-            axes_length={message.axes_length}
-            axes_radius={message.axes_radius}
+            axes_length={message.props.axes_length}
+            axes_radius={message.props.axes_radius}
           />
         ),
         // Compute click instance index from instance ID. Each visualized
@@ -191,18 +191,18 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
           <group ref={ref}>
             <Grid
               args={[
-                message.width,
-                message.height,
-                message.width_segments,
-                message.height_segments,
+                message.props.width,
+                message.props.height,
+                message.props.width_segments,
+                message.props.height_segments,
               ]}
               side={THREE.DoubleSide}
-              cellColor={message.cell_color}
-              cellThickness={message.cell_thickness}
-              cellSize={message.cell_size}
-              sectionColor={message.section_color}
-              sectionThickness={message.section_thickness}
-              sectionSize={message.section_size}
+              cellColor={message.props.cell_color}
+              cellThickness={message.props.cell_thickness}
+              cellSize={message.props.cell_size}
+              sectionColor={message.props.section_color}
+              sectionThickness={message.props.section_thickness}
+              sectionSize={message.props.section_size}
               rotation={
                 // There's redundancy here when we set the side to
                 // THREE.DoubleSide, where xy and yx should be the same.
@@ -215,17 +215,17 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                 // If we add support for FrontSide or BackSide, we should
                 // double-check that the normal directions from each of these
                 // rotations match the right-hand rule!
-                message.plane == "xz"
+                message.props.plane == "xz"
                   ? new THREE.Euler(0.0, 0.0, 0.0)
-                  : message.plane == "xy"
+                  : message.props.plane == "xy"
                     ? new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)
-                    : message.plane == "yx"
+                    : message.props.plane == "yx"
                       ? new THREE.Euler(0.0, Math.PI / 2.0, Math.PI / 2.0)
-                      : message.plane == "yz"
+                      : message.props.plane == "yz"
                         ? new THREE.Euler(0.0, 0.0, Math.PI / 2.0)
-                        : message.plane == "zx"
+                        : message.props.plane == "zx"
                           ? new THREE.Euler(0.0, Math.PI / 2.0, 0.0)
-                          : message.plane == "zy"
+                          : message.props.plane == "zy"
                             ? new THREE.Euler(
                                 -Math.PI / 2.0,
                                 0.0,
@@ -245,17 +245,20 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
         makeObject: (ref) => (
           <PointCloud
             ref={ref}
-            pointSize={message.point_size}
-            pointBallNorm={message.point_ball_norm}
+            pointSize={message.props.point_size}
+            pointBallNorm={message.props.point_ball_norm}
             points={
               new Float32Array(
-                message.points.buffer.slice(
-                  message.points.byteOffset,
-                  message.points.byteOffset + message.points.byteLength,
+                message.props.points.buffer.slice(
+                  message.props.points.byteOffset,
+                  message.props.points.byteOffset +
+                    message.props.points.byteLength,
                 ),
               )
             }
-            colors={new Float32Array(message.colors).map((val) => val / 255.0)}
+            colors={new Float32Array(message.props.colors).map(
+              (val) => val / 255.0,
+            )}
           />
         ),
       };
@@ -272,12 +275,12 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
         makeObject: (ref) => (
           <CameraFrustum
             ref={ref}
-            fov={message.fov}
-            aspect={message.aspect}
-            scale={message.scale}
-            color={message.color}
-            imageBinary={message.image_binary}
-            imageMediaType={message.image_media_type}
+            fov={message.props.fov}
+            aspect={message.props.aspect}
+            scale={message.props.scale}
+            color={message.props.color}
+            imageBinary={message.props.image_binary}
+            imageMediaType={message.props.image_media_type}
           />
         ),
       };
@@ -290,19 +293,19 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
           <group onClick={(e) => e.stopPropagation()}>
             <PivotControls
               ref={ref}
-              scale={message.scale}
-              lineWidth={message.line_width}
-              fixed={message.fixed}
-              autoTransform={message.auto_transform}
-              activeAxes={message.active_axes}
-              disableAxes={message.disable_axes}
-              disableSliders={message.disable_sliders}
-              disableRotations={message.disable_rotations}
+              scale={message.props.scale}
+              lineWidth={message.props.line_width}
+              fixed={message.props.fixed}
+              autoTransform={message.props.auto_transform}
+              activeAxes={message.props.active_axes}
+              disableAxes={message.props.disable_axes}
+              disableSliders={message.props.disable_sliders}
+              disableRotations={message.props.disable_rotations}
               disableScaling={true}
-              translationLimits={message.translation_limits}
-              rotationLimits={message.rotation_limits}
-              depthTest={message.depth_test}
-              opacity={message.opacity}
+              translationLimits={message.props.translation_limits}
+              rotationLimits={message.props.rotation_limits}
+              depthTest={message.props.depth_test}
+              opacity={message.props.opacity}
               onDrag={(l) => {
                 const attrs = viewer.nodeAttributesFromName.current;
                 if (attrs[message.name] === undefined) {
@@ -352,7 +355,7 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                     padding: "0.2em",
                   }}
                 >
-                  {message.text}
+                  {message.props.text}
                 </span>
               </div>
             </Html>
@@ -385,7 +388,9 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                       evt.stopPropagation();
                     }}
                   >
-                    <GeneratedGuiContainer containerId={message.container_id} />
+                    <GeneratedGuiContainer
+                      containerId={message.props.container_id}
+                    />
                   </Paper>
                 </ContextBridge>
               </Html>
@@ -407,8 +412,8 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
         makeObject: (ref) => (
           <GlbAsset
             ref={ref}
-            glb_data={new Uint8Array(message.glb_data)}
-            scale={message.scale}
+            glb_data={new Uint8Array(message.props.glb_data)}
+            scale={message.props.scale}
           />
         ),
       };
@@ -419,14 +424,14 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
           return (
             <group ref={ref}>
               <CatmullRomLine
-                points={message.positions}
-                closed={message.closed}
-                curveType={message.curve_type}
-                tension={message.tension}
-                lineWidth={message.line_width}
-                color={message.color}
+                points={message.props.positions}
+                closed={message.props.closed}
+                curveType={message.props.curve_type}
+                tension={message.props.tension}
+                lineWidth={message.props.line_width}
+                color={message.props.color}
                 // Sketchy cast needed due to https://github.com/pmndrs/drei/issues/1476.
-                segments={(message.segments ?? undefined) as undefined}
+                segments={(message.props.segments ?? undefined) as undefined}
               />
             </group>
           );
@@ -437,17 +442,17 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
       return {
         makeObject: (ref) => (
           <group ref={ref}>
-            {[...Array(message.positions.length - 1).keys()].map((i) => (
+            {[...Array(message.props.positions.length - 1).keys()].map((i) => (
               <CubicBezierLine
                 key={i}
-                start={message.positions[i]}
-                end={message.positions[i + 1]}
-                midA={message.control_points[2 * i]}
-                midB={message.control_points[2 * i + 1]}
-                lineWidth={message.line_width}
-                color={message.color}
+                start={message.props.positions[i]}
+                end={message.props.positions[i + 1]}
+                midA={message.props.control_points[2 * i]}
+                midB={message.props.control_points[2 * i + 1]}
+                lineWidth={message.props.line_width}
+                color={message.props.color}
                 // Sketchy cast needed due to https://github.com/pmndrs/drei/issues/1476.
-                segments={(message.segments ?? undefined) as undefined}
+                segments={(message.props.segments ?? undefined) as undefined}
               ></CubicBezierLine>
             ))}
           </group>
@@ -461,9 +466,10 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
             ref={ref}
             buffer={
               new Uint32Array(
-                message.buffer.buffer.slice(
-                  message.buffer.byteOffset,
-                  message.buffer.byteOffset + message.buffer.byteLength,
+                message.props.buffer.buffer.slice(
+                  message.props.buffer.byteOffset,
+                  message.props.buffer.byteOffset +
+                    message.props.buffer.byteLength,
                 ),
               )
             }
@@ -471,31 +477,12 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
         ),
       };
     }
+    default: {
+      console.log("Received message did not match any known types:", message);
+      return { makeObject: () => null };
+    }
   }
 }
-
-/** Component containing the three.js object and children for a particular scene node. */
-// export function SceneNodeThreeObject(props: {
-//   name: string;
-//   parent: THREE.Object3D | null;
-// }) {
-//   const viewer = React.useContext(ViewerContext)!;
-//   const message = viewer.useSceneTree(
-//     (state) => state.nodeFromName[props.name].message,
-//   );
-//   // const clickable = viewer.useSceneTree(
-//   //   (state) => state.nodeFromName[props.name].clickable,
-//   // );
-//   //
-//
-//   const unmountTypes: (typeof message.type)[] = [
-//     "TransformControlsMessage",
-//     "LabelMessage",
-//     "Gui3DMessage",
-//   ];
-//   const unmountWhenInvisible = message.type in unmountTypes;
-//   return null;
-// }
 
 export function SceneNodeThreeObject(props: {
   name: string;

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -38,6 +38,10 @@ import GeneratedGuiContainer from "./ControlPanel/Generated";
 /** Type corresponding to a zustand-style useSceneTree hook. */
 export type UseSceneTree = ReturnType<typeof useSceneTreeState>;
 
+function rgbToInt(rgb: [number, number, number]): number {
+  return (rgb[0] << 16) | (rgb[1] << 8) | rgb[2];
+}
+
 function SceneNodeThreeChildren(props: {
   name: string;
   parent: THREE.Object3D;
@@ -197,10 +201,10 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                 message.props.height_segments,
               ]}
               side={THREE.DoubleSide}
-              cellColor={message.props.cell_color}
+              cellColor={rgbToInt(message.props.cell_color)}
               cellThickness={message.props.cell_thickness}
               cellSize={message.props.cell_size}
-              sectionColor={message.props.section_color}
+              sectionColor={rgbToInt(message.props.section_color)}
               sectionThickness={message.props.section_thickness}
               sectionSize={message.props.section_size}
               rotation={
@@ -274,7 +278,7 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
             fov={message.props.fov}
             aspect={message.props.aspect}
             scale={message.props.scale}
-            color={message.props.color}
+            color={rgbToInt(message.props.color)}
             imageBinary={message.props.image_binary}
             imageMediaType={message.props.image_media_type}
           />
@@ -425,7 +429,7 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                 curveType={message.props.curve_type}
                 tension={message.props.tension}
                 lineWidth={message.props.line_width}
-                color={message.props.color}
+                color={rgbToInt(message.props.color)}
                 // Sketchy cast needed due to https://github.com/pmndrs/drei/issues/1476.
                 segments={(message.props.segments ?? undefined) as undefined}
               />
@@ -446,7 +450,7 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                 midA={message.props.control_points[2 * i]}
                 midB={message.props.control_points[2 * i + 1]}
                 lineWidth={message.props.line_width}
-                color={message.props.color}
+                color={rgbToInt(message.props.color)}
                 // Sketchy cast needed due to https://github.com/pmndrs/drei/issues/1476.
                 segments={(message.props.segments ?? undefined) as undefined}
               ></CubicBezierLine>

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -219,20 +219,16 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                 message.props.plane == "xz"
                   ? new THREE.Euler(0.0, 0.0, 0.0)
                   : message.props.plane == "xy"
-                    ? new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)
-                    : message.props.plane == "yx"
-                      ? new THREE.Euler(0.0, Math.PI / 2.0, Math.PI / 2.0)
-                      : message.props.plane == "yz"
-                        ? new THREE.Euler(0.0, 0.0, Math.PI / 2.0)
-                        : message.props.plane == "zx"
-                          ? new THREE.Euler(0.0, Math.PI / 2.0, 0.0)
-                          : message.props.plane == "zy"
-                            ? new THREE.Euler(
-                                -Math.PI / 2.0,
-                                0.0,
-                                -Math.PI / 2.0,
-                              )
-                            : undefined
+                  ? new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)
+                  : message.props.plane == "yx"
+                  ? new THREE.Euler(0.0, Math.PI / 2.0, Math.PI / 2.0)
+                  : message.props.plane == "yz"
+                  ? new THREE.Euler(0.0, 0.0, Math.PI / 2.0)
+                  : message.props.plane == "zx"
+                  ? new THREE.Euler(0.0, Math.PI / 2.0, 0.0)
+                  : message.props.plane == "zy"
+                  ? new THREE.Euler(-Math.PI / 2.0, 0.0, -Math.PI / 2.0)
+                  : undefined
               }
             />
           </group>

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -1,49 +1,39 @@
-import { useCursor } from "@react-three/drei";
+import {
+  CatmullRomLine,
+  CubicBezierLine,
+  Grid,
+  PivotControls,
+  useCursor,
+} from "@react-three/drei";
+import { useContextBridge } from "its-fine";
 import { createPortal, useFrame } from "@react-three/fiber";
 import React from "react";
 import * as THREE from "three";
 
 import { ViewerContext } from "./App";
-import { useThrottledMessageSender } from "./WebsocketFunctions";
+import {
+  makeThrottledMessageSender,
+  useThrottledMessageSender,
+} from "./WebsocketFunctions";
 import { Html } from "@react-three/drei";
-import { immerable } from "immer";
 import { useSceneTreeState } from "./SceneTreeState";
 import { ErrorBoundary } from "react-error-boundary";
 import { rayToViserCoords } from "./WorldTransformUtils";
-import { HoverableContext } from "./ThreeAssets";
+import {
+  CameraFrustum,
+  CoordinateFrame,
+  GlbAsset,
+  HoverableContext,
+  InstancedAxes,
+  PointCloud,
+  ViserImage,
+  ViserMesh,
+} from "./ThreeAssets";
 import { opencvXyFromPointerXy } from "./ClickUtils";
-
-export type MakeObject<T extends THREE.Object3D = THREE.Object3D> = (
-  ref: React.Ref<T>,
-) => React.ReactNode;
-
-/** Scenes will consist of nodes, which form a tree. */
-export class SceneNode<T extends THREE.Object3D = THREE.Object3D> {
-  [immerable] = true;
-
-  public children: string[];
-  public clickable: boolean;
-
-  constructor(
-    public readonly name: string,
-    public readonly makeObject: MakeObject<T>,
-    public readonly cleanup?: () => void,
-    /** unmountWhenInvisible is used to unmount <Html /> components when they
-     * should be hidden.
-     *
-     * https://github.com/pmndrs/drei/issues/1323
-     */
-    public readonly unmountWhenInvisible?: boolean,
-    public readonly everyFrameCallback?: () => void,
-    /** For click events on instanced nodes, like batched axes, we want to keep track of which. */
-    public readonly computeClickInstanceIndexFromInstanceId?: (
-      instanceId: number | undefined,
-    ) => number | null,
-  ) {
-    this.children = [];
-    this.clickable = false;
-  }
-}
+import { SceneNodeMessage } from "./WebsocketMessages";
+import { SplatObject } from "./Splatting/GaussianSplats";
+import { Paper } from "@mantine/core";
+import GeneratedGuiContainer from "./ControlPanel/Generated";
 
 /** Type corresponding to a zustand-style useSceneTree hook. */
 export type UseSceneTree = ReturnType<typeof useSceneTreeState>;
@@ -127,25 +117,400 @@ function SceneNodeLabel(props: { name: string }) {
   ) : null;
 }
 
+export type MakeObject = (ref: React.Ref<any>) => React.ReactNode;
+
+function useObjectFactory(message: SceneNodeMessage | undefined): {
+  makeObject: MakeObject;
+  unmountWhenInvisible?: boolean;
+  computeClickInstanceIndexFromInstanceId?: (
+    instanceId: number | undefined,
+  ) => number | null;
+} {
+  const viewer = React.useContext(ViewerContext)!;
+  const ContextBridge = useContextBridge();
+
+  if (message === undefined) return { makeObject: () => null };
+
+  switch (message.type) {
+    // Add a coordinate frame.
+    case "FrameMessage": {
+      return {
+        makeObject: (ref) => (
+          <CoordinateFrame
+            ref={ref}
+            showAxes={message.show_axes}
+            axesLength={message.axes_length}
+            axesRadius={message.axes_radius}
+            originRadius={message.origin_radius}
+          />
+        ),
+      };
+    }
+
+    // Add axes to visualize.
+    case "BatchedAxesMessage": {
+      return {
+        makeObject: (ref) => (
+          // Minor naming discrepancy: I think "batched" will be clearer to
+          // folks on the Python side, but instanced is somewhat more
+          // precise.
+          <InstancedAxes
+            ref={ref}
+            wxyzsBatched={
+              new Float32Array(
+                message.wxyzs_batched.buffer.slice(
+                  message.wxyzs_batched.byteOffset,
+                  message.wxyzs_batched.byteOffset +
+                    message.wxyzs_batched.byteLength,
+                ),
+              )
+            }
+            positionsBatched={
+              new Float32Array(
+                message.positions_batched.buffer.slice(
+                  message.positions_batched.byteOffset,
+                  message.positions_batched.byteOffset +
+                    message.positions_batched.byteLength,
+                ),
+              )
+            }
+            axes_length={message.axes_length}
+            axes_radius={message.axes_radius}
+          />
+        ),
+        // Compute click instance index from instance ID. Each visualized
+        // frame has 1 instance for each of 3 line segments.
+        computeClickInstanceIndexFromInstanceId: (instanceId) =>
+          Math.floor(instanceId! / 3),
+      };
+    }
+
+    case "GridMessage": {
+      return {
+        makeObject: (ref) => (
+          <group ref={ref}>
+            <Grid
+              args={[
+                message.width,
+                message.height,
+                message.width_segments,
+                message.height_segments,
+              ]}
+              side={THREE.DoubleSide}
+              cellColor={message.cell_color}
+              cellThickness={message.cell_thickness}
+              cellSize={message.cell_size}
+              sectionColor={message.section_color}
+              sectionThickness={message.section_thickness}
+              sectionSize={message.section_size}
+              rotation={
+                // There's redundancy here when we set the side to
+                // THREE.DoubleSide, where xy and yx should be the same.
+                //
+                // But it makes sense to keep this parameterization because
+                // specifying planes by xy seems more natural than the normal
+                // direction (z, +z, or -z), and it opens the possibility of
+                // rendering only FrontSide or BackSide grids in the future.
+                //
+                // If we add support for FrontSide or BackSide, we should
+                // double-check that the normal directions from each of these
+                // rotations match the right-hand rule!
+                message.plane == "xz"
+                  ? new THREE.Euler(0.0, 0.0, 0.0)
+                  : message.plane == "xy"
+                    ? new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)
+                    : message.plane == "yx"
+                      ? new THREE.Euler(0.0, Math.PI / 2.0, Math.PI / 2.0)
+                      : message.plane == "yz"
+                        ? new THREE.Euler(0.0, 0.0, Math.PI / 2.0)
+                        : message.plane == "zx"
+                          ? new THREE.Euler(0.0, Math.PI / 2.0, 0.0)
+                          : message.plane == "zy"
+                            ? new THREE.Euler(
+                                -Math.PI / 2.0,
+                                0.0,
+                                -Math.PI / 2.0,
+                              )
+                            : undefined
+              }
+            />
+          </group>
+        ),
+      };
+    }
+
+    // Add a point cloud.
+    case "PointCloudMessage": {
+      return {
+        makeObject: (ref) => (
+          <PointCloud
+            ref={ref}
+            pointSize={message.point_size}
+            pointBallNorm={message.point_ball_norm}
+            points={
+              new Float32Array(
+                message.points.buffer.slice(
+                  message.points.byteOffset,
+                  message.points.byteOffset + message.points.byteLength,
+                ),
+              )
+            }
+            colors={new Float32Array(message.colors).map((val) => val / 255.0)}
+          />
+        ),
+      };
+    }
+
+    // Add mesh
+    case "SkinnedMeshMessage":
+    case "MeshMessage": {
+      return { makeObject: (ref) => <ViserMesh ref={ref} {...message} /> };
+    }
+    // Add a camera frustum.
+    case "CameraFrustumMessage": {
+      return {
+        makeObject: (ref) => (
+          <CameraFrustum
+            ref={ref}
+            fov={message.fov}
+            aspect={message.aspect}
+            scale={message.scale}
+            color={message.color}
+            imageBinary={message.image_binary}
+            imageMediaType={message.image_media_type}
+          />
+        ),
+      };
+    }
+    case "TransformControlsMessage": {
+      const name = message.name;
+      const sendDragMessage = makeThrottledMessageSender(viewer, 50);
+      return {
+        makeObject: (ref) => (
+          <group onClick={(e) => e.stopPropagation()}>
+            <PivotControls
+              ref={ref}
+              scale={message.scale}
+              lineWidth={message.line_width}
+              fixed={message.fixed}
+              autoTransform={message.auto_transform}
+              activeAxes={message.active_axes}
+              disableAxes={message.disable_axes}
+              disableSliders={message.disable_sliders}
+              disableRotations={message.disable_rotations}
+              disableScaling={true}
+              translationLimits={message.translation_limits}
+              rotationLimits={message.rotation_limits}
+              depthTest={message.depth_test}
+              opacity={message.opacity}
+              onDrag={(l) => {
+                const attrs = viewer.nodeAttributesFromName.current;
+                if (attrs[message.name] === undefined) {
+                  attrs[message.name] = {};
+                }
+
+                const wxyz = new THREE.Quaternion();
+                wxyz.setFromRotationMatrix(l);
+                const position = new THREE.Vector3().setFromMatrixPosition(l);
+
+                const nodeAttributes = attrs[message.name]!;
+                nodeAttributes.wxyz = [wxyz.w, wxyz.x, wxyz.y, wxyz.z];
+                nodeAttributes.position = position.toArray();
+                sendDragMessage({
+                  type: "TransformControlsUpdateMessage",
+                  name: name,
+                  wxyz: nodeAttributes.wxyz,
+                  position: nodeAttributes.position,
+                });
+              }}
+            />
+          </group>
+        ),
+        unmountWhenInvisible: true,
+      };
+    }
+    // Add a 2D label.
+    case "LabelMessage": {
+      return {
+        makeObject: (ref) => (
+          // We wrap with <group /> because Html doesn't implement THREE.Object3D.
+          <group ref={ref}>
+            <Html>
+              <div
+                style={{
+                  width: "10em",
+                  fontSize: "0.8em",
+                  transform: "translateX(0.1em) translateY(0.5em)",
+                }}
+              >
+                <span
+                  style={{
+                    background: "#fff",
+                    border: "1px solid #777",
+                    borderRadius: "0.2em",
+                    color: "#333",
+                    padding: "0.2em",
+                  }}
+                >
+                  {message.text}
+                </span>
+              </div>
+            </Html>
+          </group>
+        ),
+        unmountWhenInvisible: true,
+      };
+    }
+    case "Gui3DMessage": {
+      return {
+        makeObject: (ref) => {
+          // We wrap with <group /> because Html doesn't implement
+          // THREE.Object3D. The initial position is intended to be
+          // off-screen; it will be overwritten with the actual position
+          // after the component is mounted.
+          return (
+            <group ref={ref} position={new THREE.Vector3(1e8, 1e8, 1e8)}>
+              <Html>
+                <ContextBridge>
+                  <Paper
+                    style={{
+                      width: "18em",
+                      fontSize: "0.875em",
+                      marginLeft: "0.5em",
+                      marginTop: "0.5em",
+                    }}
+                    shadow="0 0 0.8em 0 rgba(0,0,0,0.1)"
+                    pb="0.25em"
+                    onPointerDown={(evt) => {
+                      evt.stopPropagation();
+                    }}
+                  >
+                    <GeneratedGuiContainer containerId={message.container_id} />
+                  </Paper>
+                </ContextBridge>
+              </Html>
+            </group>
+          );
+        },
+        unmountWhenInvisible: true,
+      };
+    }
+    // Add an image.
+    case "ImageMessage": {
+      return {
+        makeObject: (ref) => <ViserImage ref={ref} {...message} />,
+      };
+    }
+    // Add a glTF/GLB asset.
+    case "GlbMessage": {
+      return {
+        makeObject: (ref) => (
+          <GlbAsset
+            ref={ref}
+            glb_data={new Uint8Array(message.glb_data)}
+            scale={message.scale}
+          />
+        ),
+      };
+    }
+    case "CatmullRomSplineMessage": {
+      return {
+        makeObject: (ref) => {
+          return (
+            <group ref={ref}>
+              <CatmullRomLine
+                points={message.positions}
+                closed={message.closed}
+                curveType={message.curve_type}
+                tension={message.tension}
+                lineWidth={message.line_width}
+                color={message.color}
+                // Sketchy cast needed due to https://github.com/pmndrs/drei/issues/1476.
+                segments={(message.segments ?? undefined) as undefined}
+              />
+            </group>
+          );
+        },
+      };
+    }
+    case "CubicBezierSplineMessage": {
+      return {
+        makeObject: (ref) => (
+          <group ref={ref}>
+            {[...Array(message.positions.length - 1).keys()].map((i) => (
+              <CubicBezierLine
+                key={i}
+                start={message.positions[i]}
+                end={message.positions[i + 1]}
+                midA={message.control_points[2 * i]}
+                midB={message.control_points[2 * i + 1]}
+                lineWidth={message.line_width}
+                color={message.color}
+                // Sketchy cast needed due to https://github.com/pmndrs/drei/issues/1476.
+                segments={(message.segments ?? undefined) as undefined}
+              ></CubicBezierLine>
+            ))}
+          </group>
+        ),
+      };
+    }
+    case "GaussianSplatsMessage": {
+      return {
+        makeObject: (ref) => (
+          <SplatObject
+            ref={ref}
+            buffer={
+              new Uint32Array(
+                message.buffer.buffer.slice(
+                  message.buffer.byteOffset,
+                  message.buffer.byteOffset + message.buffer.byteLength,
+                ),
+              )
+            }
+          />
+        ),
+      };
+    }
+  }
+}
+
 /** Component containing the three.js object and children for a particular scene node. */
+// export function SceneNodeThreeObject(props: {
+//   name: string;
+//   parent: THREE.Object3D | null;
+// }) {
+//   const viewer = React.useContext(ViewerContext)!;
+//   const message = viewer.useSceneTree(
+//     (state) => state.nodeFromName[props.name].message,
+//   );
+//   // const clickable = viewer.useSceneTree(
+//   //   (state) => state.nodeFromName[props.name].clickable,
+//   // );
+//   //
+//
+//   const unmountTypes: (typeof message.type)[] = [
+//     "TransformControlsMessage",
+//     "LabelMessage",
+//     "Gui3DMessage",
+//   ];
+//   const unmountWhenInvisible = message.type in unmountTypes;
+//   return null;
+// }
+
 export function SceneNodeThreeObject(props: {
   name: string;
   parent: THREE.Object3D | null;
 }) {
   const viewer = React.useContext(ViewerContext)!;
-  const makeObject = viewer.useSceneTree(
-    (state) => state.nodeFromName[props.name]?.makeObject,
+  const message = viewer.useSceneTree(
+    (state) => state.nodeFromName[props.name]?.message,
   );
-  const unmountWhenInvisible = viewer.useSceneTree(
-    (state) => state.nodeFromName[props.name]?.unmountWhenInvisible,
-  );
-  const everyFrameCallback = viewer.useSceneTree(
-    (state) => state.nodeFromName[props.name]?.everyFrameCallback,
-  );
-  const computeClickInstanceIndexFromInstanceId = viewer.useSceneTree(
-    (state) =>
-      state.nodeFromName[props.name]?.computeClickInstanceIndexFromInstanceId,
-  );
+  const {
+    makeObject,
+    unmountWhenInvisible,
+    computeClickInstanceIndexFromInstanceId,
+  } = useObjectFactory(message);
+
   const [unmount, setUnmount] = React.useState(false);
   const clickable =
     viewer.useSceneTree((state) => state.nodeFromName[props.name]?.clickable) ??
@@ -217,7 +582,6 @@ export function SceneNodeThreeObject(props: {
   useFrame(
     () => {
       const attrs = viewer.nodeAttributesFromName.current[props.name];
-      everyFrameCallback && everyFrameCallback();
 
       // Unmount when invisible.
       // Examples: <Html /> components, PivotControls.

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -28,6 +28,7 @@ import {
   PointCloud,
   ViserImage,
   ViserMesh,
+  rgbToInt,
 } from "./ThreeAssets";
 import { opencvXyFromPointerXy } from "./ClickUtils";
 import { SceneNodeMessage } from "./WebsocketMessages";
@@ -37,10 +38,6 @@ import GeneratedGuiContainer from "./ControlPanel/Generated";
 
 /** Type corresponding to a zustand-style useSceneTree hook. */
 export type UseSceneTree = ReturnType<typeof useSceneTreeState>;
-
-function rgbToInt(rgb: [number, number, number]): number {
-  return (rgb[0] << 16) | (rgb[1] << 8) | rgb[2];
-}
 
 function SceneNodeThreeChildren(props: {
   name: string;
@@ -222,16 +219,20 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                 message.props.plane == "xz"
                   ? new THREE.Euler(0.0, 0.0, 0.0)
                   : message.props.plane == "xy"
-                  ? new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)
-                  : message.props.plane == "yx"
-                  ? new THREE.Euler(0.0, Math.PI / 2.0, Math.PI / 2.0)
-                  : message.props.plane == "yz"
-                  ? new THREE.Euler(0.0, 0.0, Math.PI / 2.0)
-                  : message.props.plane == "zx"
-                  ? new THREE.Euler(0.0, Math.PI / 2.0, 0.0)
-                  : message.props.plane == "zy"
-                  ? new THREE.Euler(-Math.PI / 2.0, 0.0, -Math.PI / 2.0)
-                  : undefined
+                    ? new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)
+                    : message.props.plane == "yx"
+                      ? new THREE.Euler(0.0, Math.PI / 2.0, Math.PI / 2.0)
+                      : message.props.plane == "yz"
+                        ? new THREE.Euler(0.0, 0.0, Math.PI / 2.0)
+                        : message.props.plane == "zx"
+                          ? new THREE.Euler(0.0, Math.PI / 2.0, 0.0)
+                          : message.props.plane == "zy"
+                            ? new THREE.Euler(
+                                -Math.PI / 2.0,
+                                0.0,
+                                -Math.PI / 2.0,
+                              )
+                            : undefined
               }
             />
           </group>

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -218,20 +218,16 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                 message.props.plane == "xz"
                   ? new THREE.Euler(0.0, 0.0, 0.0)
                   : message.props.plane == "xy"
-                    ? new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)
-                    : message.props.plane == "yx"
-                      ? new THREE.Euler(0.0, Math.PI / 2.0, Math.PI / 2.0)
-                      : message.props.plane == "yz"
-                        ? new THREE.Euler(0.0, 0.0, Math.PI / 2.0)
-                        : message.props.plane == "zx"
-                          ? new THREE.Euler(0.0, Math.PI / 2.0, 0.0)
-                          : message.props.plane == "zy"
-                            ? new THREE.Euler(
-                                -Math.PI / 2.0,
-                                0.0,
-                                -Math.PI / 2.0,
-                              )
-                            : undefined
+                  ? new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)
+                  : message.props.plane == "yx"
+                  ? new THREE.Euler(0.0, Math.PI / 2.0, Math.PI / 2.0)
+                  : message.props.plane == "yz"
+                  ? new THREE.Euler(0.0, 0.0, Math.PI / 2.0)
+                  : message.props.plane == "zx"
+                  ? new THREE.Euler(0.0, Math.PI / 2.0, 0.0)
+                  : message.props.plane == "zy"
+                  ? new THREE.Euler(-Math.PI / 2.0, 0.0, -Math.PI / 2.0)
+                  : undefined
               }
             />
           </group>

--- a/src/viser/client/src/SceneTreeState.tsx
+++ b/src/viser/client/src/SceneTreeState.tsx
@@ -1,38 +1,53 @@
 import React from "react";
-import { MakeObject, SceneNode } from "./SceneTree";
-import { CoordinateFrame } from "./ThreeAssets";
 import * as THREE from "three";
+import { SceneNodeMessage } from "./WebsocketMessages";
 import { create } from "zustand";
-import { subscribeWithSelector } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
-interface SceneTreeState {
-  nodeFromName: { [name: string]: undefined | SceneNode };
-  // Putting this into SceneNode makes the scene tree table much harder to implement.
+export type SceneNode = {
+  message: SceneNodeMessage;
+  children: string[];
+  clickable: boolean;
+};
+
+type SceneTreeState = {
+  nodeFromName: { [name: string]: SceneNode | undefined };
   labelVisibleFromName: { [name: string]: boolean };
-}
-export interface SceneTreeActions extends SceneTreeState {
+};
+
+type SceneTreeActions = {
   setClickable(name: string, clickable: boolean): void;
-  addSceneNode(nodes: SceneNode): void;
+  addSceneNode(message: SceneNodeMessage): void;
   removeSceneNode(name: string): void;
   resetScene(): void;
   setLabelVisibility(name: string, labelVisibility: boolean): void;
-}
+};
 
-// Create default scene tree state.
-const rootAxesTemplate: MakeObject<THREE.Group> = (ref) => (
-  <CoordinateFrame ref={ref} />
-);
-
-const rootNodeTemplate = new SceneNode<THREE.Group>("", (ref) => (
-  <group ref={ref} />
-)) as SceneNode<THREE.Object3D>;
-
-const rootAxesNode = new SceneNode(
-  "/WorldAxes",
-  rootAxesTemplate,
-) as SceneNode<THREE.Object3D>;
-rootNodeTemplate.children.push("/WorldAxes");
+// Pre-defined scene nodes.
+export const rootNodeTemplate: SceneNode = {
+  message: {
+    type: "FrameMessage",
+    name: "",
+    show_axes: false,
+    axes_length: 0.5,
+    axes_radius: 0.0125,
+    origin_radius: 0.025,
+  },
+  children: ["/WorldAxes"],
+  clickable: false,
+};
+const worldAxesNodeTemplate: SceneNode = {
+  message: {
+    type: "FrameMessage",
+    name: "/WorldAxes",
+    show_axes: false,
+    axes_length: 0.5,
+    axes_radius: 0.0125,
+    origin_radius: 0.025,
+  },
+  children: [],
+  clickable: false,
+};
 
 /** Declare a scene state, and return a hook for accessing it. Note that we put
 effort into avoiding a global state! */
@@ -43,85 +58,82 @@ export function useSceneTreeState(
 ) {
   return React.useState(() =>
     create(
-      subscribeWithSelector(
-        immer<SceneTreeState & SceneTreeActions>((set) => ({
-          nodeFromName: { "": rootNodeTemplate, "/WorldAxes": rootAxesNode },
-          labelVisibleFromName: {},
-          setClickable: (name, clickable) =>
-            set((state) => {
-              const node = state.nodeFromName[name];
-              if (node !== undefined) node.clickable = clickable;
-            }),
-          addSceneNode: (node) =>
-            set((state) => {
-              const existingNode = state.nodeFromName[node.name];
-              if (existingNode !== undefined) {
-                // Node already exists.
-                delete nodeRefFromName.current[node.name];
-                existingNode.cleanup && existingNode.cleanup(); // Free resources.
-                state.nodeFromName[node.name] = {
-                  ...node,
-                  children: existingNode.children,
-                };
-              } else {
-                // Node doesn't exist yet!
-                // TODO: this assumes the parent exists. We could probably merge this with addSceneNodeMakeParents.
-                const parent_name = node.name.split("/").slice(0, -1).join("/");
-                state.nodeFromName[node.name] = node;
-                state.nodeFromName[parent_name]!.children.push(node.name);
-              }
-            }),
-          removeSceneNode: (name) =>
-            set((state) => {
-              if (!(name in state.nodeFromName)) {
-                console.log("Skipping scene node removal for " + name);
-                return;
-              }
+      immer<SceneTreeState & SceneTreeActions>((set) => ({
+        nodeFromName: {
+          "": rootNodeTemplate,
+          "/WorldAxes": worldAxesNodeTemplate,
+        },
+        labelVisibleFromName: {},
+        setClickable: (name, clickable) =>
+          set((state) => {
+            const node = state.nodeFromName[name];
+            if (node !== undefined) node.clickable = clickable;
+          }),
+        addSceneNode: (message) =>
+          set((state) => {
+            const existingNode = state.nodeFromName[message.name];
+            if (existingNode !== undefined) {
+              // Node already exists.
+              delete nodeRefFromName.current[message.name];
+              state.nodeFromName[message.name] = {
+                ...existingNode,
+                message: message,
+              };
+            } else {
+              // Node doesn't exist yet!
+              const parent_name = message.name
+                .split("/")
+                .slice(0, -1)
+                .join("/");
+              state.nodeFromName[message.name] = {
+                message: message,
+                children: [],
+                clickable: false,
+              };
+              state.nodeFromName[parent_name]!.children.push(message.name);
+            }
+          }),
+        removeSceneNode: (name) =>
+          set((state) => {
+            if (!(name in state.nodeFromName)) {
+              console.log("Skipping scene node removal for " + name);
+              return;
+            }
 
-              // Remove this scene node and all children.
-              const removeNames: string[] = [];
-              function findChildrenRecursive(name: string) {
-                removeNames.push(name);
-                state.nodeFromName[name]!.children.forEach(
-                  findChildrenRecursive,
-                );
-              }
-              findChildrenRecursive(name);
+            // Remove this scene node and all children.
+            const removeNames: string[] = [];
+            function findChildrenRecursive(name: string) {
+              removeNames.push(name);
+              state.nodeFromName[name]!.children.forEach(findChildrenRecursive);
+            }
+            findChildrenRecursive(name);
 
-              removeNames.forEach((removeName) => {
-                const node = state.nodeFromName[removeName]!;
-                node.cleanup && node.cleanup(); // Free resources.
-                delete state.nodeFromName[removeName];
-                delete nodeRefFromName.current[removeName];
-              });
+            removeNames.forEach((removeName) => {
+              delete state.nodeFromName[removeName];
+              delete nodeRefFromName.current[removeName];
+            });
 
-              // Remove node from parent's children list.
-              const parent_name = name.split("/").slice(0, -1).join("/");
-              state.nodeFromName[parent_name]!.children = state.nodeFromName[
-                parent_name
-              ]!.children.filter((child_name) => child_name !== name);
-            }),
-          resetScene: () =>
-            set((state) => {
-              // For scene resets: we need to retain the object references created for the root and world frame nodes.
-              for (const key of Object.keys(state.nodeFromName)) {
-                if (key !== "" && key !== "/WorldAxes")
-                  delete state.nodeFromName[key];
-              }
-              Object.values(state.nodeFromName).forEach((node) => {
-                // Free resources.
-                if (node === undefined || node.cleanup === undefined) return;
-                node.cleanup();
-              });
-              state.nodeFromName[""] = rootNodeTemplate;
-              state.nodeFromName["/WorldAxes"] = rootAxesNode;
-            }),
-          setLabelVisibility: (name, labelVisibility) =>
-            set((state) => {
-              state.labelVisibleFromName[name] = labelVisibility;
-            }),
-        })),
-      ),
+            // Remove node from parent's children list.
+            const parent_name = name.split("/").slice(0, -1).join("/");
+            state.nodeFromName[parent_name]!.children = state.nodeFromName[
+              parent_name
+            ]!.children.filter((child_name) => child_name !== name);
+          }),
+        resetScene: () =>
+          set((state) => {
+            // For scene resets: we need to retain the object references created for the root and world frame nodes.
+            for (const key of Object.keys(state.nodeFromName)) {
+              if (key !== "" && key !== "/WorldAxes")
+                delete state.nodeFromName[key];
+            }
+            state.nodeFromName[""] = rootNodeTemplate;
+            state.nodeFromName["/WorldAxes"] = worldAxesNodeTemplate;
+          }),
+        setLabelVisibility: (name, labelVisibility) =>
+          set((state) => {
+            state.labelVisibleFromName[name] = labelVisibility;
+          }),
+      })),
     ),
   )[0];
 }

--- a/src/viser/client/src/SceneTreeState.tsx
+++ b/src/viser/client/src/SceneTreeState.tsx
@@ -40,7 +40,7 @@ const worldAxesNodeTemplate: SceneNode = {
   message: {
     type: "FrameMessage",
     name: "/WorldAxes",
-    show_axes: false,
+    show_axes: true,
     axes_length: 0.5,
     axes_radius: 0.0125,
     origin_radius: 0.025,

--- a/src/viser/client/src/SceneTreeState.tsx
+++ b/src/viser/client/src/SceneTreeState.tsx
@@ -19,6 +19,7 @@ type SceneTreeActions = {
   setClickable(name: string, clickable: boolean): void;
   addSceneNode(message: SceneNodeMessage): void;
   removeSceneNode(name: string): void;
+  updateSceneNode(name: string, updates: { [key: string]: any }): void;
   resetScene(): void;
   setLabelVisibility(name: string, labelVisibility: boolean): void;
 };
@@ -28,10 +29,12 @@ export const rootNodeTemplate: SceneNode = {
   message: {
     type: "FrameMessage",
     name: "",
-    show_axes: false,
-    axes_length: 0.5,
-    axes_radius: 0.0125,
-    origin_radius: 0.025,
+    props: {
+      show_axes: false,
+      axes_length: 0.5,
+      axes_radius: 0.0125,
+      origin_radius: 0.025,
+    },
   },
   children: ["/WorldAxes"],
   clickable: false,
@@ -40,10 +43,12 @@ const worldAxesNodeTemplate: SceneNode = {
   message: {
     type: "FrameMessage",
     name: "/WorldAxes",
-    show_axes: true,
-    axes_length: 0.5,
-    axes_radius: 0.0125,
-    origin_radius: 0.025,
+    props: {
+      show_axes: true,
+      axes_length: 0.5,
+      axes_radius: 0.0125,
+      origin_radius: 0.025,
+    },
   },
   children: [],
   clickable: false,
@@ -118,6 +123,13 @@ export function useSceneTreeState(
             state.nodeFromName[parent_name]!.children = state.nodeFromName[
               parent_name
             ]!.children.filter((child_name) => child_name !== name);
+          }),
+        updateSceneNode: (name, updates) =>
+          set((state) => {
+            state.nodeFromName[name]!.message.props = {
+              ...state.nodeFromName[name]!.message.props,
+              ...updates,
+            };
           }),
         resetScene: () =>
           set((state) => {

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -475,16 +475,16 @@ export const ViserMesh = React.forwardRef<
       message.props.material == "standard" || message.props.wireframe
         ? new THREE.MeshStandardMaterial(standardArgs)
         : message.props.material == "toon3"
-          ? new THREE.MeshToonMaterial({
-              gradientMap: generateGradientMap(3),
-              ...standardArgs,
-            })
-          : message.props.material == "toon5"
-            ? new THREE.MeshToonMaterial({
-                gradientMap: generateGradientMap(5),
-                ...standardArgs,
-              })
-            : assertUnreachable(message.props.material);
+        ? new THREE.MeshToonMaterial({
+            gradientMap: generateGradientMap(3),
+            ...standardArgs,
+          })
+        : message.props.material == "toon5"
+        ? new THREE.MeshToonMaterial({
+            gradientMap: generateGradientMap(5),
+            ...standardArgs,
+          })
+        : assertUnreachable(message.props.material);
     const geometry = new THREE.BufferGeometry();
     geometry.setAttribute(
       "position",

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -471,16 +471,16 @@ export const ViserMesh = React.forwardRef<
       message.props.material == "standard" || message.props.wireframe
         ? new THREE.MeshStandardMaterial(standardArgs)
         : message.props.material == "toon3"
-        ? new THREE.MeshToonMaterial({
-            gradientMap: generateGradientMap(3),
-            ...standardArgs,
-          })
-        : message.props.material == "toon5"
-        ? new THREE.MeshToonMaterial({
-            gradientMap: generateGradientMap(5),
-            ...standardArgs,
-          })
-        : assertUnreachable(message.props.material);
+          ? new THREE.MeshToonMaterial({
+              gradientMap: generateGradientMap(3),
+              ...standardArgs,
+            })
+          : message.props.material == "toon5"
+            ? new THREE.MeshToonMaterial({
+                gradientMap: generateGradientMap(5),
+                ...standardArgs,
+              })
+            : assertUnreachable(message.props.material);
     const geometry = new THREE.BufferGeometry();
     geometry.setAttribute(
       "position",
@@ -580,10 +580,12 @@ export const ViserMesh = React.forwardRef<
       // disposal.
       geometry.dispose();
       material.dispose();
-      skeleton !== undefined && skeleton.dispose();
 
-      const state = viewer.skinnedMeshState.current[message.name];
-      state.initialized = false;
+      if (message.type === "SkinnedMeshMessage") {
+        skeleton !== undefined && skeleton.dispose();
+        const state = viewer.skinnedMeshState.current[message.name];
+        state.initialized = false;
+      }
     };
   }, [message]);
 

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -50,6 +50,9 @@ type AllPossibleThreeJSMaterials =
   | LineBasicMaterial
   | LineDashedMaterial;
 
+export function rgbToInt(rgb: [number, number, number]): number {
+  return (rgb[0] << 16) | (rgb[1] << 8) | rgb[2];
+}
 const originGeom = new THREE.SphereGeometry(1.0);
 const originMaterial = new THREE.MeshBasicMaterial({ color: 0xecec00 });
 
@@ -443,7 +446,8 @@ export const ViserMesh = React.forwardRef<
     return texture;
   };
   const standardArgs = {
-    color: message.props.color ?? undefined,
+    color:
+      message.props.color === null ? undefined : rgbToInt(message.props.color),
     vertexColors: message.props.vertex_colors !== null,
     wireframe: message.props.wireframe,
     transparent: message.props.opacity !== null,

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -523,10 +523,6 @@ export const ViserMesh = React.forwardRef<
         bones.push(new THREE.Bone());
       }
       const boneInverses: THREE.Matrix4[] = [];
-      viewer.skinnedMeshState.current[props.name] = {
-        initialized: false,
-        poses: [],
-      };
       bones.forEach((bone, i) => {
         const wxyz = props.bone_wxyzs[i];
         const position = props.bone_positions[i];
@@ -542,11 +538,6 @@ export const ViserMesh = React.forwardRef<
         bone.position.set(position[0], position[1], position[2]);
         bone.matrixAutoUpdate = false;
         bone.matrixWorldAutoUpdate = false;
-
-        viewer.skinnedMeshState.current[props.name].poses.push({
-          wxyz: wxyz,
-          position: position,
-        });
       });
       const skeleton = new THREE.Skeleton(bones, boneInverses);
       setSkeleton(skeleton);
@@ -585,10 +576,7 @@ export const ViserMesh = React.forwardRef<
       // disposal.
       geometry.dispose();
       material.dispose();
-      if (props.type === "SkinnedMeshMessage") {
-        delete viewer.skinnedMeshState.current[props.name];
-        skeleton !== undefined && skeleton.dispose();
-      }
+      skeleton !== undefined && skeleton.dispose();
     };
   }, [props]);
 

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -50,7 +50,7 @@ type AllPossibleThreeJSMaterials =
   | LineBasicMaterial
   | LineDashedMaterial;
 
-export function rgbToInt(rgb: [number, number, number]): number {
+function rgbToInt(rgb: [number, number, number]): number {
   return (rgb[0] << 16) | (rgb[1] << 8) | rgb[2];
 }
 const originGeom = new THREE.SphereGeometry(1.0);

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -471,16 +471,16 @@ export const ViserMesh = React.forwardRef<
       message.props.material == "standard" || message.props.wireframe
         ? new THREE.MeshStandardMaterial(standardArgs)
         : message.props.material == "toon3"
-          ? new THREE.MeshToonMaterial({
-              gradientMap: generateGradientMap(3),
-              ...standardArgs,
-            })
-          : message.props.material == "toon5"
-            ? new THREE.MeshToonMaterial({
-                gradientMap: generateGradientMap(5),
-                ...standardArgs,
-              })
-            : assertUnreachable(message.props.material);
+        ? new THREE.MeshToonMaterial({
+            gradientMap: generateGradientMap(3),
+            ...standardArgs,
+          })
+        : message.props.material == "toon5"
+        ? new THREE.MeshToonMaterial({
+            gradientMap: generateGradientMap(5),
+            ...standardArgs,
+          })
+        : assertUnreachable(message.props.material);
     const geometry = new THREE.BufferGeometry();
     geometry.setAttribute(
       "position",

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -94,12 +94,14 @@ export interface ScenePointerEnableMessage {
 export interface CameraFrustumMessage {
   type: "CameraFrustumMessage";
   name: string;
-  fov: number;
-  aspect: number;
-  scale: number;
-  color: number;
-  image_media_type: "image/jpeg" | "image/png" | null;
-  image_binary: Uint8Array | null;
+  props: {
+    fov: number;
+    aspect: number;
+    scale: number;
+    color: number;
+    image_media_type: "image/jpeg" | "image/png" | null;
+    image_binary: Uint8Array | null;
+  };
 }
 /** GlTF message.
  *
@@ -108,8 +110,7 @@ export interface CameraFrustumMessage {
 export interface GlbMessage {
   type: "GlbMessage";
   name: string;
-  glb_data: Uint8Array;
-  scale: number;
+  props: { glb_data: Uint8Array; scale: number };
 }
 /** Coordinate frame message.
  *
@@ -118,10 +119,12 @@ export interface GlbMessage {
 export interface FrameMessage {
   type: "FrameMessage";
   name: string;
-  show_axes: boolean;
-  axes_length: number;
-  axes_radius: number;
-  origin_radius: number;
+  props: {
+    show_axes: boolean;
+    axes_length: number;
+    axes_radius: number;
+    origin_radius: number;
+  };
 }
 /** Batched axes message.
  *
@@ -133,10 +136,12 @@ export interface FrameMessage {
 export interface BatchedAxesMessage {
   type: "BatchedAxesMessage";
   name: string;
-  wxyzs_batched: Uint8Array;
-  positions_batched: Uint8Array;
-  axes_length: number;
-  axes_radius: number;
+  props: {
+    wxyzs_batched: Uint8Array;
+    positions_batched: Uint8Array;
+    axes_length: number;
+    axes_radius: number;
+  };
 }
 /** Grid message. Helpful for visualizing things like ground planes.
  *
@@ -145,17 +150,19 @@ export interface BatchedAxesMessage {
 export interface GridMessage {
   type: "GridMessage";
   name: string;
-  width: number;
-  height: number;
-  width_segments: number;
-  height_segments: number;
-  plane: "xz" | "xy" | "yx" | "yz" | "zx" | "zy";
-  cell_color: number;
-  cell_thickness: number;
-  cell_size: number;
-  section_color: number;
-  section_thickness: number;
-  section_size: number;
+  props: {
+    width: number;
+    height: number;
+    width_segments: number;
+    height_segments: number;
+    plane: "xz" | "xy" | "yx" | "yz" | "zx" | "zy";
+    cell_color: number;
+    cell_thickness: number;
+    cell_size: number;
+    section_color: number;
+    section_thickness: number;
+    section_size: number;
+  };
 }
 /** Add a 2D label to the scene.
  *
@@ -164,7 +171,7 @@ export interface GridMessage {
 export interface LabelMessage {
   type: "LabelMessage";
   name: string;
-  text: string;
+  props: { text: string };
 }
 /** Add a 3D gui element to the scene.
  *
@@ -172,9 +179,8 @@ export interface LabelMessage {
  */
 export interface Gui3DMessage {
   type: "Gui3DMessage";
-  order: number;
   name: string;
-  container_id: string;
+  props: { order: number; container_id: string };
 }
 /** Point cloud message.
  *
@@ -188,10 +194,12 @@ export interface Gui3DMessage {
 export interface PointCloudMessage {
   type: "PointCloudMessage";
   name: string;
-  points: Uint8Array;
-  colors: Uint8Array;
-  point_size: number;
-  point_ball_norm: number;
+  props: {
+    points: Uint8Array;
+    colors: Uint8Array;
+    point_size: number;
+    point_ball_norm: number;
+  };
 }
 /** Mesh message.
  *
@@ -202,38 +210,40 @@ export interface PointCloudMessage {
 export interface MeshMessage {
   type: "MeshMessage";
   name: string;
-  vertices: Uint8Array;
-  faces: Uint8Array;
-  color: number | null;
-  vertex_colors: Uint8Array | null;
-  wireframe: boolean;
-  opacity: number | null;
-  flat_shading: boolean;
-  side: "front" | "back" | "double";
-  material: "standard" | "toon3" | "toon5";
+  props: {
+    vertices: Uint8Array;
+    faces: Uint8Array;
+    color: number | null;
+    vertex_colors: Uint8Array | null;
+    wireframe: boolean;
+    opacity: number | null;
+    flat_shading: boolean;
+    side: "front" | "back" | "double";
+    material: "standard" | "toon3" | "toon5";
+  };
 }
-/** Mesh message.
- *
- * Vertices are internally canonicalized to float32, faces to uint32.
+/** Skinned mesh message.
  *
  * (automatically generated)
  */
 export interface SkinnedMeshMessage {
   type: "SkinnedMeshMessage";
   name: string;
-  vertices: Uint8Array;
-  faces: Uint8Array;
-  color: number | null;
-  vertex_colors: Uint8Array | null;
-  wireframe: boolean;
-  opacity: number | null;
-  flat_shading: boolean;
-  side: "front" | "back" | "double";
-  material: "standard" | "toon3" | "toon5";
-  bone_wxyzs: [number, number, number, number][];
-  bone_positions: [number, number, number][];
-  skin_indices: Uint8Array;
-  skin_weights: Uint8Array;
+  props: {
+    vertices: Uint8Array;
+    faces: Uint8Array;
+    color: number | null;
+    vertex_colors: Uint8Array | null;
+    wireframe: boolean;
+    opacity: number | null;
+    flat_shading: boolean;
+    side: "front" | "back" | "double";
+    material: "standard" | "toon3" | "toon5";
+    bone_wxyzs: [number, number, number, number][];
+    bone_positions: [number, number, number][];
+    skin_indices: Uint8Array;
+    skin_weights: Uint8Array;
+  };
 }
 /** Server -> client message to set a skinned mesh bone's orientation.
  *
@@ -266,18 +276,20 @@ export interface SetBonePositionMessage {
 export interface TransformControlsMessage {
   type: "TransformControlsMessage";
   name: string;
-  scale: number;
-  line_width: number;
-  fixed: boolean;
-  auto_transform: boolean;
-  active_axes: [boolean, boolean, boolean];
-  disable_axes: boolean;
-  disable_sliders: boolean;
-  disable_rotations: boolean;
-  translation_limits: [[number, number], [number, number], [number, number]];
-  rotation_limits: [[number, number], [number, number], [number, number]];
-  depth_test: boolean;
-  opacity: number;
+  props: {
+    scale: number;
+    line_width: number;
+    fixed: boolean;
+    auto_transform: boolean;
+    active_axes: [boolean, boolean, boolean];
+    disable_axes: boolean;
+    disable_sliders: boolean;
+    disable_rotations: boolean;
+    translation_limits: [[number, number], [number, number], [number, number]];
+    rotation_limits: [[number, number], [number, number], [number, number]];
+    depth_test: boolean;
+    opacity: number;
+  };
 }
 /** Server -> client message to set the camera's position.
  *
@@ -362,10 +374,12 @@ export interface BackgroundImageMessage {
 export interface ImageMessage {
   type: "ImageMessage";
   name: string;
-  media_type: "image/jpeg" | "image/png";
-  data: Uint8Array;
-  render_width: number;
-  render_height: number;
+  props: {
+    media_type: "image/jpeg" | "image/png";
+    data: Uint8Array;
+    render_width: number;
+    render_height: number;
+  };
 }
 /** Remove a particular node from the scene.
  *
@@ -598,7 +612,7 @@ export interface GuiAddSliderMessage {
   max: number;
   step: number | null;
   precision: number;
-  marks: { value: number; label?: string }[] | null;
+  marks: { value: number; label: string | null }[] | null;
 }
 /** GuiAddMultiSliderMessage(order: 'float', id: 'str', label: 'str', container_id: 'str', hint: 'Optional[str]', value: 'Any', visible: 'bool', disabled: 'bool', min: 'float', max: 'float', step: 'Optional[float]', min_range: 'Optional[float]', precision: 'int', fixed_endpoints: 'bool' = False, marks: 'Optional[Tuple[GuiSliderMark, ...]]' = None)
  *
@@ -620,7 +634,7 @@ export interface GuiAddMultiSliderMessage {
   min_range: number | null;
   precision: number;
   fixed_endpoints: boolean;
-  marks: { value: number; label?: string }[] | null;
+  marks: { value: number; label: string | null }[] | null;
 }
 /** GuiAddNumberMessage(order: 'float', id: 'str', label: 'str', container_id: 'str', hint: 'Optional[str]', value: 'float', visible: 'bool', disabled: 'bool', precision: 'int', step: 'float', min: 'Optional[float]', max: 'Optional[float]')
  *
@@ -806,6 +820,15 @@ export interface GuiUpdateMessage {
   id: string;
   updates: Partial<GuiAddComponentMessage>;
 }
+/** Sent client<->server when any property of a GUI component is changed.
+ *
+ * (automatically generated)
+ */
+export interface SceneNodeUpdateMessage {
+  type: "SceneNodeUpdateMessage";
+  name: string;
+  updates: { [key: string]: any };
+}
 /** Message from server->client to configure parts of the GUI.
  *
  * (automatically generated)
@@ -854,13 +877,15 @@ export interface ThemeConfigurationMessage {
 export interface CatmullRomSplineMessage {
   type: "CatmullRomSplineMessage";
   name: string;
-  positions: [number, number, number][];
-  curve_type: "centripetal" | "chordal" | "catmullrom";
-  tension: number;
-  closed: boolean;
-  line_width: number;
-  color: number;
-  segments: number | null;
+  props: {
+    positions: [number, number, number][];
+    curve_type: "centripetal" | "chordal" | "catmullrom";
+    tension: number;
+    closed: boolean;
+    line_width: number;
+    color: number;
+    segments: number | null;
+  };
 }
 /** Message from server->client carrying Cubic Bezier spline information.
  *
@@ -869,11 +894,13 @@ export interface CatmullRomSplineMessage {
 export interface CubicBezierSplineMessage {
   type: "CubicBezierSplineMessage";
   name: string;
-  positions: [number, number, number][];
-  control_points: [number, number, number][];
-  line_width: number;
-  color: number;
-  segments: number | null;
+  props: {
+    positions: [number, number, number][];
+    control_points: [number, number, number][];
+    line_width: number;
+    color: number;
+    segments: number | null;
+  };
 }
 /** Message from server->client carrying splattable Gaussians.
  *
@@ -882,7 +909,7 @@ export interface CubicBezierSplineMessage {
 export interface GaussianSplatsMessage {
   type: "GaussianSplatsMessage";
   name: string;
-  buffer: Uint8Array;
+  props: { buffer: Uint8Array };
 }
 /** Message from server->client requesting a render of the current viewport.
  *
@@ -1027,6 +1054,7 @@ export type Message =
   | GuiCloseModalMessage
   | GuiRemoveMessage
   | GuiUpdateMessage
+  | SceneNodeUpdateMessage
   | ThemeConfigurationMessage
   | CatmullRomSplineMessage
   | CubicBezierSplineMessage

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -98,7 +98,7 @@ export interface CameraFrustumMessage {
     fov: number;
     aspect: number;
     scale: number;
-    color: number;
+    color: [number, number, number];
     image_media_type: "image/jpeg" | "image/png" | null;
     image_binary: Uint8Array | null;
   };
@@ -156,10 +156,10 @@ export interface GridMessage {
     width_segments: number;
     height_segments: number;
     plane: "xz" | "xy" | "yx" | "yz" | "zx" | "zy";
-    cell_color: number;
+    cell_color: [number, number, number];
     cell_thickness: number;
     cell_size: number;
-    section_color: number;
+    section_color: [number, number, number];
     section_thickness: number;
     section_size: number;
   };
@@ -213,7 +213,7 @@ export interface MeshMessage {
   props: {
     vertices: Uint8Array;
     faces: Uint8Array;
-    color: number | null;
+    color: [number, number, number] | null;
     vertex_colors: Uint8Array | null;
     wireframe: boolean;
     opacity: number | null;
@@ -232,7 +232,7 @@ export interface SkinnedMeshMessage {
   props: {
     vertices: Uint8Array;
     faces: Uint8Array;
-    color: number | null;
+    color: [number, number, number] | null;
     vertex_colors: Uint8Array | null;
     wireframe: boolean;
     opacity: number | null;
@@ -883,7 +883,7 @@ export interface CatmullRomSplineMessage {
     tension: number;
     closed: boolean;
     line_width: number;
-    color: number;
+    color: [number, number, number];
     segments: number | null;
   };
 }
@@ -898,7 +898,7 @@ export interface CubicBezierSplineMessage {
     positions: [number, number, number][];
     control_points: [number, number, number][];
     line_width: number;
-    color: number;
+    color: [number, number, number];
     segments: number | null;
   };
 }

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1075,3 +1075,50 @@ export type GuiAddComponentMessage =
   | GuiAddTextMessage
   | GuiAddDropdownMessage
   | GuiAddButtonGroupMessage;
+const typeSetSceneNodeMessage = new Set([
+  "CameraFrustumMessage",
+  "GlbMessage",
+  "FrameMessage",
+  "BatchedAxesMessage",
+  "GridMessage",
+  "LabelMessage",
+  "Gui3DMessage",
+  "PointCloudMessage",
+  "MeshMessage",
+  "SkinnedMeshMessage",
+  "TransformControlsMessage",
+  "ImageMessage",
+  "CatmullRomSplineMessage",
+  "CubicBezierSplineMessage",
+  "GaussianSplatsMessage",
+]);
+export function isSceneNodeMessage(
+  message: Message,
+): message is SceneNodeMessage {
+  return typeSetSceneNodeMessage.has(message.type);
+}
+const typeSetGuiAddComponentMessage = new Set([
+  "GuiAddFolderMessage",
+  "GuiAddMarkdownMessage",
+  "GuiAddProgressBarMessage",
+  "GuiAddPlotlyMessage",
+  "GuiAddTabGroupMessage",
+  "GuiAddButtonMessage",
+  "GuiAddUploadButtonMessage",
+  "GuiAddSliderMessage",
+  "GuiAddMultiSliderMessage",
+  "GuiAddNumberMessage",
+  "GuiAddRgbMessage",
+  "GuiAddRgbaMessage",
+  "GuiAddCheckboxMessage",
+  "GuiAddVector2Message",
+  "GuiAddVector3Message",
+  "GuiAddTextMessage",
+  "GuiAddDropdownMessage",
+  "GuiAddButtonGroupMessage",
+]);
+export function isGuiAddComponentMessage(
+  message: Message,
+): message is GuiAddComponentMessage {
+  return typeSetGuiAddComponentMessage.has(message.type);
+}

--- a/src/viser/client/src/WebsocketMessages.tsx
+++ b/src/viser/client/src/WebsocketMessages.tsx
@@ -1051,6 +1051,7 @@ export type SceneNodeMessage =
   | PointCloudMessage
   | MeshMessage
   | SkinnedMeshMessage
+  | TransformControlsMessage
   | ImageMessage
   | CatmullRomSplineMessage
   | CubicBezierSplineMessage

--- a/src/viser/client/src/WebsocketMessages.tsx
+++ b/src/viser/client/src/WebsocketMessages.tsx
@@ -193,14 +193,6 @@ export interface PointCloudMessage {
   point_size: number;
   point_ball_norm: number;
 }
-/** Message for a bone of a skinned mesh.
- *
- * (automatically generated)
- */
-export interface MeshBoneMessage {
-  type: "MeshBoneMessage";
-  name: string;
-}
 /** Mesh message.
  *
  * Vertices are internally canonicalized to float32, faces to uint32.
@@ -992,7 +984,6 @@ export type Message =
   | LabelMessage
   | Gui3DMessage
   | PointCloudMessage
-  | MeshBoneMessage
   | MeshMessage
   | SkinnedMeshMessage
   | SetBoneOrientationMessage
@@ -1049,6 +1040,21 @@ export type Message =
   | ShareUrlUpdated
   | ShareUrlDisconnect
   | SetGuiPanelLabelMessage;
+export type SceneNodeMessage =
+  | CameraFrustumMessage
+  | GlbMessage
+  | FrameMessage
+  | BatchedAxesMessage
+  | GridMessage
+  | LabelMessage
+  | Gui3DMessage
+  | PointCloudMessage
+  | MeshMessage
+  | SkinnedMeshMessage
+  | ImageMessage
+  | CatmullRomSplineMessage
+  | CubicBezierSplineMessage
+  | GaussianSplatsMessage;
 export type GuiAddComponentMessage =
   | GuiAddFolderMessage
   | GuiAddMarkdownMessage

--- a/src/viser/infra/_messages.py
+++ b/src/viser/infra/_messages.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import abc
+import dataclasses
 import functools
 import warnings
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Type, TypeVar, cast
@@ -55,6 +56,9 @@ def _prepare_for_serialization(value: Any, annotation: object) -> Any:
         return float(value)
     if annotation is int or isinstance(value, onp.integer):
         return int(value)
+
+    if dataclasses.is_dataclass(annotation):
+        return _prepare_for_serialization(vars(value), dict)
 
     # Recursively handle tuples.
     if isinstance(value, tuple):

--- a/src/viser/infra/_typescript_interface_gen.py
+++ b/src/viser/infra/_typescript_interface_gen.py
@@ -83,14 +83,14 @@ def _get_ts_type(typ: Type[Any]) -> str:
         args = get_args(typ)
         assert len(args) == 2
         return "{ [key: " + _get_ts_type(args[0]) + "]: " + _get_ts_type(args[1]) + " }"
-    elif is_typeddict(typ):
+    elif is_typeddict(typ) or dataclasses.is_dataclass(typ):
         hints = get_type_hints(typ)
         optional_keys = getattr(typ, "__optional_keys__", [])
 
         def fmt(key):
             val = hints[key]
             optional = key in optional_keys
-            if get_origin(val) is NotRequired:
+            if is_typeddict(typ) and get_origin(val) is NotRequired:
                 val = get_args(val)[0]
             ret = f"'{key}'{'?' if optional else ''}" + ": " + _get_ts_type(val)
             return ret

--- a/src/viser/infra/_typescript_interface_gen.py
+++ b/src/viser/infra/_typescript_interface_gen.py
@@ -158,7 +158,17 @@ def generate_typescript_interfaces(message_cls: Type[Message]) -> str:
             out_lines.append(f"  | {cls_name}")
         out_lines[-1] = out_lines[-1] + ";"
 
-    interfaces = "\n".join(out_lines) + "\n"
+    for tag, cls_names in tag_map.items():
+        out_lines.extend(
+            [
+                f"const typeSet{tag} = new Set(['" + "', '".join(cls_names) + "']);"
+                f"export function is{tag}(message: Message): message is {tag}" + " {",
+                f"    return typeSet{tag}.has(message.type);",
+                "}",
+            ]
+        )
+
+    generated_typescript = "\n".join(out_lines) + "\n"
 
     # Add header and return.
     return (
@@ -172,5 +182,5 @@ def generate_typescript_interfaces(message_cls: Type[Message]) -> str:
                 "",
             ]
         )
-        + interfaces
+        + generated_typescript
     )

--- a/sync_message_defs.py
+++ b/sync_message_defs.py
@@ -12,7 +12,7 @@ if __name__ == "__main__":
 
     # Write to file.
     target_path = pathlib.Path(__file__).parent / pathlib.Path(
-        "src/viser/client/src/WebsocketMessages.tsx"
+        "src/viser/client/src/WebsocketMessages.ts"
     )
     assert target_path.exists()
     target_path.write_text(defs)


### PR DESCRIPTION
Refactored scene tree on both client and server:
- Support dynamic scene node prop updates from the Python API.
- Client-side state structure is simpler, faster, better-structured.
- Reduced likelihood of some websocket backpressure issues.