### PR TITLE
Remove Cholesky logic from Gaussian shader

### DIFF
--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -1228,11 +1228,7 @@ class SceneApi:
 
         # Get cholesky factor of covariance. This helps retain precision when
         # we convert to float16.
-        cov_cholesky_triu = (
-            np.linalg.cholesky(covariances.astype(np.float64) + np.ones(3) * 1e-7)
-            .swapaxes(-1, -2)  # tril => triu
-            .reshape((-1, 9))[:, np.array([0, 1, 2, 4, 5, 8])]
-        )
+        cov_triu = covariances.reshape((-1, 9))[:, np.array([0, 1, 2, 4, 5, 8])]
         buffer = np.concatenate(
             [
                 # First texelFetch.
@@ -1241,8 +1237,8 @@ class SceneApi:
                 # - w (32 bits): this is reserved for use by the renderer.
                 np.zeros((num_gaussians, 4), dtype=np.uint8),
                 # Second texelFetch.
-                # - xyz (96 bits): upper-triangular Cholesky factor of covariance.
-                cov_cholesky_triu.astype(np.float16).copy().view(np.uint8),
+                # - xyz (96 bits): upper-triangular terms of covariance.
+                cov_triu.astype(np.float16).copy().view(np.uint8),
                 # - w (32 bits): rgba.
                 colors_to_uint8(rgbs),
                 colors_to_uint8(opacities),

--- a/src/viser/client/src/Splatting/GaussianSplats.tsx
+++ b/src/viser/client/src/Splatting/GaussianSplats.tsx
@@ -170,21 +170,20 @@ const GaussianSplatMaterial = /* @__PURE__ */ shaderMaterial(
 
     // Get covariance terms from int buffer.
     uint rgbaUint32 = intBufferData.w;
-    vec2 chol01 = unpackHalf2x16(intBufferData.x);
-    vec2 chol23 = unpackHalf2x16(intBufferData.y);
-    vec2 chol45 = unpackHalf2x16(intBufferData.z);
+    vec2 triu01 = unpackHalf2x16(intBufferData.x);
+    vec2 triu23 = unpackHalf2x16(intBufferData.y);
+    vec2 triu45 = unpackHalf2x16(intBufferData.z);
 
     // Transition in.
     float startTime = 0.8 * float(sortedIndex) / float(numGaussians);
     float cov_scale = smoothstep(startTime, startTime + 0.2, transitionInState);
 
     // Do the actual splatting.
-    mat3 chol = mat3(
-        chol01.x, chol01.y, chol23.x,
-        0.,       chol23.y, chol45.x,
-        0.,       0.,       chol45.y
+    mat3 cov3d = mat3(
+        triu01.x, triu01.y, triu23.x,
+        triu01.y, triu23.y, triu45.x,
+        triu23.x, triu45.x, triu45.y
     );
-    mat3 cov3d = chol * transpose(chol) * cov_scale;
     mat3 J = mat3(
         // Matrices are column-major.
         focal.x / c_cam.z, 0., 0.0,


### PR DESCRIPTION
This was meant to improve numerical precision but it seems not worth the hassle, particularly for covariances that are PSD but not PD.