### PR TITLE
Fix 0.0.0.0-related issues

### DIFF
--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -603,8 +603,15 @@ class ViserServer(_BackwardsCompatibilityShim if not TYPE_CHECKING else object):
 
         # Form status print.
         port = server._port  # Port may have changed.
-        http_url = f"http://{host}:{port}"
-        ws_url = f"ws://{host}:{port}"
+        if host == "0.0.0.0":
+            # 0.0.0.0 is not a real IP and people are often confused by it;
+            # we'll just print localhost. This is questionable from a security
+            # perspective, but probably fine for our use cases.
+            http_url = f"http://localhost:{port}"
+            ws_url = f"ws://localhost:{port}"
+        else:
+            http_url = f"http://{host}:{port}"
+            ws_url = f"ws://{host}:{port}"
         table = Table(
             title=None,
             show_header=False,
@@ -613,7 +620,15 @@ class ViserServer(_BackwardsCompatibilityShim if not TYPE_CHECKING else object):
         )
         table.add_row("HTTP", http_url)
         table.add_row("Websocket", ws_url)
-        rich.print(Panel(table, title="[bold]viser[/bold]", expand=False))
+        rich.print(
+            Panel(
+                table,
+                title="[bold]viser[/bold]"
+                if host == "0.0.0.0"
+                else "[bold]viser[/bold]",
+                expand=False,
+            )
+        )
 
         self._share_tunnel: ViserTunnel | None = None
 

--- a/src/viser/client/src/Splatting/GaussianSplats.tsx
+++ b/src/viser/client/src/Splatting/GaussianSplats.tsx
@@ -30,6 +30,7 @@ import { shaderMaterial } from "@react-three/drei";
 import { SorterWorkerIncoming } from "./SplatSortWorker";
 import { create } from "zustand";
 import { Object3D } from "three";
+import { v4 as uuidv4 } from "uuid";
 
 /**Global splat state.*/
 interface SplatState {
@@ -253,7 +254,7 @@ export const SplatObject = React.forwardRef<
   const setBuffer = splatContext((state) => state.setBuffer);
   const removeBuffer = splatContext((state) => state.removeBuffer);
   const nodeRefFromId = splatContext((state) => state.nodeRefFromId);
-  const name = React.useMemo(() => crypto.randomUUID(), [buffer]);
+  const name = React.useMemo(() => uuidv4(), [buffer]);
 
   const [obj, setRef] = React.useState<THREE.Group | null>(null);
 


### PR DESCRIPTION
- `crypto.randomUUID()` isn't available when sites are accessed via `http://0.0.0.0`. Switched to `uuid` package.
- Avoid printing `0.0.0.0`; this seems like a frequent point of confusion for people.