### PR TITLE
Fix overflow artifacts for scene tree table

### DIFF
--- a/src/viser/client/src/ControlPanel/SceneTreeTable.css.ts
+++ b/src/viser/client/src/ControlPanel/SceneTreeTable.css.ts
@@ -5,8 +5,14 @@ export const tableWrapper = style({
   border: "1px solid",
   borderColor: vars.colors.defaultBorder,
   borderRadius: vars.radius.xs,
+  padding: "0.1em 0",
+  overflowX: "auto",
+  display: "flex",
+  flexDirection: "column",
+  gap: "0",
 });
-export const icon = style({
+
+export const caretIcon = style({
   opacity: 0.5,
   height: "1em",
   width: "1em",
@@ -16,8 +22,8 @@ export const icon = style({
 export const tableRow = style({
   display: "flex",
   alignItems: "center",
-  gap: "0.4em",
+  gap: "0.2em",
   padding: "0 0.25em",
-  lineHeight: "2.25em",
+  lineHeight: "2em",
   fontSize: "0.875em",
 });

--- a/src/viser/client/src/ControlPanel/SceneTreeTable.tsx
+++ b/src/viser/client/src/ControlPanel/SceneTreeTable.tsx
@@ -1,5 +1,5 @@
 import { ViewerContext } from "../App";
-import { Box, Stack, Tooltip } from "@mantine/core";
+import { Box, ScrollArea, Stack, Tooltip } from "@mantine/core";
 import {
   IconCaretDown,
   IconCaretRight,
@@ -7,11 +7,7 @@ import {
   IconEyeOff,
 } from "@tabler/icons-react";
 import React from "react";
-import {
-  icon as caretIcon,
-  tableRow,
-  tableWrapper,
-} from "./SceneTreeTable.css";
+import { caretIcon, tableRow, tableWrapper } from "./SceneTreeTable.css";
 import { useDisclosure } from "@mantine/hooks";
 
 /* Table for seeing an overview of the scene tree, toggling visibility, etc. * */
@@ -21,7 +17,7 @@ export default function SceneTreeTable() {
     (state) => state.nodeFromName[""]!.children,
   );
   return (
-    <Stack className={tableWrapper} style={{ padding: "0.1em 0" }} gap={0}>
+    <ScrollArea className={tableWrapper}>
       {childrenName.map((name) => (
         <SceneTreeTableRow
           nodeName={name}
@@ -30,7 +26,7 @@ export default function SceneTreeTable() {
           indentCount={0}
         />
       ))}
-    </Stack>
+    </ScrollArea>
   );
 }
 
@@ -101,18 +97,22 @@ const SceneTreeTableRow = React.memo(function SceneTreeTableRow(props: {
             <IconCaretRight className={caretIcon} />
           )}
         </Box>
-        <Tooltip label="Override visibility">
-          <VisibleIcon
-            style={{
-              cursor: "pointer",
-              opacity: isVisibleEffective ? 0.85 : 0.25,
-            }}
-            onClick={(evt) => {
-              evt.stopPropagation();
-              setOverrideVisibility(props.nodeName, !isVisible);
-            }}
-          />
-        </Tooltip>
+        <Box style={{ width: "1.5em", height: "1.5em" }}>
+          <Tooltip label="Override visibility">
+            <VisibleIcon
+              style={{
+                cursor: "pointer",
+                opacity: isVisibleEffective ? 0.85 : 0.25,
+                width: "1.5em",
+                height: "1.5em",
+              }}
+              onClick={(evt) => {
+                evt.stopPropagation();
+                setOverrideVisibility(props.nodeName, !isVisible);
+              }}
+            />
+          </Tooltip>
+        </Box>
         <Box>
           {props.nodeName
             .split("/")

--- a/src/viser/client/src/ControlPanel/SceneTreeTable.tsx
+++ b/src/viser/client/src/ControlPanel/SceneTreeTable.tsx
@@ -1,5 +1,5 @@
 import { ViewerContext } from "../App";
-import { Box, ScrollArea, Stack, Tooltip } from "@mantine/core";
+import { Box, ScrollArea, Tooltip } from "@mantine/core";
 import {
   IconCaretDown,
   IconCaretRight,


### PR DESCRIPTION
before:
<img width="317" alt="image" src="https://github.com/user-attachments/assets/320d39ad-9485-4eb6-a515-f310b86741dd">


after:
<img width="308" alt="image" src="https://github.com/user-attachments/assets/90f62093-a613-4ebd-b223-38075140b7ee">
