### PR TITLE
Fix scene node edge cases

### DIFF
--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -329,6 +329,10 @@ class _ClickableSceneNodeHandle(SceneNodeHandle):
             self._impl.click_cb.clear()
         else:
             self._impl.click_cb = [cb for cb in self._impl.click_cb if cb != callback]
+        if len(self._impl.click_cb) == 0:
+            self._impl.api._websock_interface.queue_message(
+                _messages.SetSceneNodeClickableMessage(self._impl.name, False)
+            )
 
 
 class CameraFrustumHandle(

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -298,7 +298,7 @@ function useMessageHandler() {
         const attr = viewer.nodeAttributesFromName.current;
         if (attr[message.name] === undefined) attr[message.name] = {};
         attr[message.name]!.wxyz = message.wxyz;
-        if (attr[message.name]!.poseUpdateState == "updated")
+        if (attr[message.name]!.poseUpdateState != "waitForMakeObject")
           attr[message.name]!.poseUpdateState = "needsUpdate";
         break;
       }
@@ -306,7 +306,7 @@ function useMessageHandler() {
         const attr = viewer.nodeAttributesFromName.current;
         if (attr[message.name] === undefined) attr[message.name] = {};
         attr[message.name]!.position = message.position;
-        if (attr[message.name]!.poseUpdateState == "updated")
+        if (attr[message.name]!.poseUpdateState != "waitForMakeObject")
           attr[message.name]!.poseUpdateState = "needsUpdate";
         break;
       }

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -735,14 +735,10 @@ export function SceneNodeThreeObject(props: {
 
       if (attrs.poseUpdateState == "needsUpdate") {
         attrs.poseUpdateState = "updated";
-        const wxyz = attrs.wxyz;
-        if (wxyz !== undefined) {
-          obj.quaternion.set(wxyz[1], wxyz[2], wxyz[3], wxyz[0]);
-        }
-        const position = attrs.position;
-        if (position !== undefined) {
-          obj.position.set(position[0], position[1], position[2]);
-        }
+        const wxyz = attrs.wxyz ?? [1, 0, 0, 0];
+        obj.quaternion.set(wxyz[1], wxyz[2], wxyz[3], wxyz[0]);
+        const position = attrs.position ?? [0, 0, 0];
+        obj.position.set(position[0], position[1], position[2]);
 
         // Update matrices if necessary. This is necessary for PivotControls.
         if (!obj.matrixAutoUpdate) obj.updateMatrix();

--- a/src/viser/client/src/SceneTreeState.tsx
+++ b/src/viser/client/src/SceneTreeState.tsx
@@ -137,6 +137,13 @@ export function useSceneTreeState(
           }),
         updateSceneNode: (name, updates) =>
           set((state) => {
+            if (state.nodeFromName[name] === undefined) {
+              console.error(
+                `Attempted to update non-existent node ${name} with updates:`,
+                updates,
+              );
+              return;
+            }
             state.nodeFromName[name]!.message.props = {
               ...state.nodeFromName[name]!.message.props,
               ...updates,


### PR DESCRIPTION
- Clickable state wasn't being reset after callbacks are removed
- Poses weren't being updated when a new scene node with identity pose replaces (has the same name as) an existing scene node
- Scene nodes that are added, have attributes updated, removed, added, then removed again would crash new clients
    - A better fix for this would refactor viser's state management system