### PR TITLE
Add image decoding to CameraFrustumHandle when ._image is set via binary

### DIFF
--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -100,6 +100,19 @@ def _encode_image_binary(
     return media_type, binary
 
 
+def _decode_image_binary(
+    binary: bytes,
+    format: Literal["image/png", "image/jpeg"],
+) -> np.ndarray:
+    if format not in ("image/png", "image/jpeg"):
+        raise ValueError(f"Unsupported media type: {format}")
+
+    extension = ".png" if format == "image/png" else ".jpeg"
+    with io.BytesIO(binary) as buf:
+        image = iio.imread(buf, extension=extension)
+    return image
+
+
 TVector = TypeVar("TVector", bound=tuple)
 
 

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -100,16 +100,9 @@ def _encode_image_binary(
     return media_type, binary
 
 
-def _decode_image_binary(
-    binary: bytes,
-    format: Literal["image/png", "image/jpeg"],
-) -> np.ndarray:
-    if format not in ("image/png", "image/jpeg"):
-        raise ValueError(f"Unsupported media type: {format}")
-
-    extension = ".png" if format == "image/png" else ".jpeg"
+def _decode_image_binary(binary: bytes) -> np.ndarray:
     with io.BytesIO(binary) as buf:
-        image = iio.imread(buf, extension=extension)
+        image = iio.imread(buf)
     return image
 
 

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -364,7 +364,7 @@ class CameraFrustumHandle(
         if self._image is None and self._image_data is not None:
             from ._scene_api import _decode_image_binary
 
-            self._image = _decode_image_binary(self._image_data, self.image_media_type)
+            self._image = _decode_image_binary(self._image_data)
 
         return self._image
 

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -361,6 +361,11 @@ class CameraFrustumHandle(
     @property
     def image(self) -> np.ndarray | None:
         """Current content of the image. Synchronized automatically when assigned."""
+        if self._image is None and self._image_data is not None:
+            from ._scene_api import _decode_image_binary
+
+            self._image = _decode_image_binary(self._image_data, self.image_media_type)
+
         return self._image
 
     @image.setter


### PR DESCRIPTION
Related to #351 

To speed up image visualization in Camera Frustum by loading directly from disk it is possible to do

```python
from pathlib import Path

frustum_handle._image_data = Path("some_image.jpeg").read_bytes()
frustum_handle.image_media_type = "image/jpeg"
```

This creates a weird situation where `frustum_handle.image` is `None` because the internal `._image` was never set.

This PR fixes that behaviour by decoding the `._image_data` attribute if it exists **and** `._image` is `None`