### PR TITLE
Report exceptions thrown from thread pool workers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
     "pyright>=1.1.308",
-    "ruff==0.6.2",
+    "ruff>=0.9.3",
     "pre-commit==3.3.2",
     "pytest",
     "hypothesis[numpy]",

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -46,6 +46,7 @@ from ._scene_handles import (
     _TransformControlsState,
     colors_to_uint8,
 )
+from ._threadpool_exceptions import print_threadpool_errors
 
 if TYPE_CHECKING:
     import trimesh
@@ -105,9 +106,9 @@ TVector = TypeVar("TVector", bound=tuple)
 
 def cast_vector(vector: TVector | np.ndarray, length: int) -> TVector:
     if not isinstance(vector, tuple):
-        assert cast(np.ndarray, vector).shape == (
-            length,
-        ), f"Expected vector of shape {(length,)}, but got {vector.shape} instead"
+        assert cast(np.ndarray, vector).shape == (length,), (
+            f"Expected vector of shape {(length,)}, but got {vector.shape} instead"
+        )
     return cast(TVector, tuple(map(float, vector)))
 
 
@@ -1046,9 +1047,9 @@ class SceneApi:
             Handle for manipulating scene node.
         """
         colors_cast = colors_to_uint8(np.asarray(colors))
-        assert (
-            len(points.shape) == 2 and points.shape[-1] == 3
-        ), "Shape of points should be (N, 3)."
+        assert len(points.shape) == 2 and points.shape[-1] == 3, (
+            "Shape of points should be (N, 3)."
+        )
         assert colors_cast.shape in {
             points.shape,
             (3,),
@@ -1674,7 +1675,9 @@ class SceneApi:
             if asyncio.iscoroutinefunction(cb):
                 await cb(handle)
             else:
-                self._thread_executor.submit(cb, handle)
+                self._thread_executor.submit(cb, handle).add_done_callback(
+                    print_threadpool_errors
+                )
         if handle._impl_aux.sync_cb is not None:
             handle._impl_aux.sync_cb(client_id, handle)
 
@@ -1699,7 +1702,9 @@ class SceneApi:
             if asyncio.iscoroutinefunction(cb):
                 await cb(event)
             else:
-                self._thread_executor.submit(cb, event)
+                self._thread_executor.submit(cb, event).add_done_callback(
+                    print_threadpool_errors
+                )
 
     async def _handle_scene_pointer_updates(
         self, client_id: ClientId, message: _messages.ScenePointerMessage
@@ -1719,7 +1724,9 @@ class SceneApi:
         if asyncio.iscoroutinefunction(self._scene_pointer_cb):
             await self._scene_pointer_cb(event)
         else:
-            self._thread_executor.submit(self._scene_pointer_cb, event)
+            self._thread_executor.submit(
+                self._scene_pointer_cb, event
+            ).add_done_callback(print_threadpool_errors)
 
     def on_pointer_event(
         self, event_type: Literal["click", "rect-select"]

--- a/src/viser/_threadpool_exceptions.py
+++ b/src/viser/_threadpool_exceptions.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import sys
+import traceback
+from concurrent.futures import Future
+from typing import Any
+
+
+def print_threadpool_errors(future: Future[Any]) -> None:
+    """Print errors from a Future in a ThreadPool, should be used with
+    `add_done_callback`."""
+    if future.cancelled():
+        print("Task was cancelled", file=sys.stderr)
+        return
+
+    exc = future.exception()
+    if exc is not None:
+        print("Task failed with exception:", file=sys.stderr)
+        traceback.print_exception(type(exc), exc, exc.__traceback__)

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -65,9 +65,9 @@ class StateSerializer:
     def insert_sleep(self, duration: float) -> None:
         """Insert a sleep into the recorded file. This can be useful for
         dynamic 3D data."""
-        assert (
-            self._handler._record_handle is not None
-        ), "serialize() was already called!"
+        assert self._handler._record_handle is not None, (
+            "serialize() was already called!"
+        )
         self._time += duration
 
     def serialize(self) -> bytes:
@@ -78,9 +78,9 @@ class StateSerializer:
         Returns:
             The recording as bytes.
         """
-        assert (
-            self._handler._record_handle is not None
-        ), "serialize() was already called!"
+        assert self._handler._record_handle is not None, (
+            "serialize() was already called!"
+        )
         import viser
 
         packed_bytes = msgspec.msgpack.encode(
@@ -133,9 +133,9 @@ class WebsockMessageHandler:
         callback: Callable[[ClientId, TMessage], None | Coroutine] | None = None,
     ):
         """Unregister a handler for a particular message type."""
-        assert (
-            message_cls in self._incoming_handlers
-        ), "Tried to unregister a handler that hasn't been registered."
+        assert message_cls in self._incoming_handlers, (
+            "Tried to unregister a handler that hasn't been registered."
+        )
         if callback is None:
             self._incoming_handlers.pop(message_cls)
         else:


### PR DESCRIPTION
Non-`async` callbacks are run by thread pool workers, which capture + store exceptions in Future objects. This was causing silent failures.