### PR TITLE
Fix non-integer marks for sliders

### DIFF
--- a/src/viser/client/src/components/MultiSlider.tsx
+++ b/src/viser/client/src/components/MultiSlider.tsx
@@ -72,11 +72,15 @@ export default function MultiSliderComponent({
             ? [
                 {
                   value: min,
-                  label: `${parseInt(min.toFixed(6))}`,
+                  // The regex here removes trailing zeros and the decimal
+                  // point if the number is an integer.
+                  label: `${min.toFixed(6).replace(/\.?0+$/, "")}`,
                 },
                 {
                   value: max,
-                  label: `${parseInt(max.toFixed(6))}`,
+                  // The regex here removes trailing zeros and the decimal
+                  // point if the number is an integer.
+                  label: `${max.toFixed(6).replace(/\.?0+$/, "")}`,
                 },
               ]
             : marks

--- a/src/viser/client/src/components/Slider.tsx
+++ b/src/viser/client/src/components/Slider.tsx
@@ -77,11 +77,15 @@ export default function SliderComponent({
             ? [
                 {
                   value: min,
-                  label: `${parseInt(min.toFixed(6))}`,
+                  // The regex here removes trailing zeros and the decimal
+                  // point if the number is an integer.
+                  label: `${min.toFixed(6).replace(/\.?0+$/, "")}`,
                 },
                 {
                   value: max,
-                  label: `${parseInt(max.toFixed(6))}`,
+                  // The regex here removes trailing zeros and the decimal
+                  // point if the number is an integer.
+                  label: `${max.toFixed(6).replace(/\.?0+$/, "")}`,
                 },
               ]
             : marks


### PR DESCRIPTION
It looks like we added `parseInt` calls on slider marker labels in #166, which breaks non-integer min/max values.