### PR TITLE
Add `save_immediately=` flag to file downloads

### DIFF
--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -217,7 +217,7 @@ class GuiApi:
             _messages.GuiUpdateMessage, self._handle_gui_updates
         )
         self._websock_interface.register_handler(
-            _messages.FileTransferStart, self._handle_file_transfer_start
+            _messages.FileTransferStartUpload, self._handle_file_transfer_start
         )
         self._websock_interface.register_handler(
             _messages.FileTransferPart,
@@ -291,7 +291,7 @@ class GuiApi:
             handle_state.sync_cb(client_id, updates_cast)
 
     def _handle_file_transfer_start(
-        self, client_id: ClientId, message: _messages.FileTransferStart
+        self, client_id: ClientId, message: _messages.FileTransferStartUpload
     ) -> None:
         if message.source_component_uuid not in self._gui_input_handle_from_uuid:
             return

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1337,11 +1337,32 @@ class GetRenderResponseMessage(Message):
 
 
 @dataclasses.dataclass
-class FileTransferStart(Message):
-    """Signal that a file is about to be sent."""
+class FileTransferStartUpload(Message):
+    """Signal that a file is about to be sent.
 
-    source_component_uuid: Optional[str]
-    """Origin GUI component, used for client->server file uploads."""
+    This message is used to upload files from clients to the server.
+    """
+
+    source_component_uuid: str
+    transfer_uuid: str
+    filename: str
+    mime_type: str
+    part_count: int
+    size_bytes: int
+
+    @override
+    def redundancy_key(self) -> str:
+        return type(self).__name__ + "-" + self.transfer_uuid
+
+
+@dataclasses.dataclass
+class FileTransferStartDownload(Message):
+    """Signal that a file is about to be sent.
+
+    This message is used to send files to clients from the server.
+    """
+
+    save_immediately: bool
     transfer_uuid: str
     filename: str
     mime_type: str

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -385,7 +385,11 @@ class ClientHandle(_BackwardsCompatibilityShim if not TYPE_CHECKING else object)
         return self._websock_connection.atomic()
 
     def send_file_download(
-        self, filename: str, content: bytes, chunk_size: int = 1024 * 1024
+        self,
+        filename: str,
+        content: bytes,
+        chunk_size: int = 1024 * 1024,
+        save_immediately: bool = False,
     ) -> None:
         """Send a file for a client or clients to download.
 
@@ -393,6 +397,9 @@ class ClientHandle(_BackwardsCompatibilityShim if not TYPE_CHECKING else object)
             filename: Name of the file to send. Used to infer MIME type.
             content: Content of the file.
             chunk_size: Number of bytes to send at a time.
+            save_immediately: Whether to save the file immediately. If `False`,
+                a link to the file will be shown as a notification. Being able to
+                right click the link and choose "Save as..." can be useful.
         """
         mime_type = mimetypes.guess_type(filename, strict=False)[0]
         if mime_type is None:
@@ -405,8 +412,8 @@ class ClientHandle(_BackwardsCompatibilityShim if not TYPE_CHECKING else object)
 
         uuid = _make_uuid()
         self._websock_connection.queue_message(
-            _messages.FileTransferStart(
-                source_component_uuid=None,
+            _messages.FileTransferStartDownload(
+                save_immediately=save_immediately,
                 transfer_uuid=uuid,
                 filename=filename,
                 mime_type=mime_type,
@@ -977,7 +984,11 @@ class ViserServer(_BackwardsCompatibilityShim if not TYPE_CHECKING else object):
         return self._websock_server.atomic()
 
     def send_file_download(
-        self, filename: str, content: bytes, chunk_size: int = 1024 * 1024
+        self,
+        filename: str,
+        content: bytes,
+        chunk_size: int = 1024 * 1024,
+        save_immediately: bool = False,
     ) -> None:
         """Send a file for a client or clients to download.
 
@@ -985,9 +996,12 @@ class ViserServer(_BackwardsCompatibilityShim if not TYPE_CHECKING else object):
             filename: Name of the file to send. Used to infer MIME type.
             content: Content of the file.
             chunk_size: Number of bytes to send at a time.
+            save_immediately: Whether to save the file immediately. If `False`,
+                a link to the file will be shown as a notification. Being able to
+                right click the link and choose "Save as..." can be useful.
         """
         for client in self.get_clients().values():
-            client.send_file_download(filename, content, chunk_size)
+            client.send_file_download(filename, content, chunk_size, save_immediately)
 
     def get_event_loop(self) -> asyncio.AbstractEventLoop:
         """Get the asyncio event loop used by the Viser background thread. This

--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -6,11 +6,7 @@ import { useInView } from "react-intersection-observer";
 
 import { Notifications } from "@mantine/notifications";
 
-import {
-  Environment,
-  PerformanceMonitor,
-  Stats,
-} from "@react-three/drei";
+import { Environment, PerformanceMonitor, Stats } from "@react-three/drei";
 import * as THREE from "three";
 import { Canvas, useThree, useFrame } from "@react-three/fiber";
 

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -522,7 +522,7 @@ export interface GuiSliderMessage {
     _marks: { value: number; label: string | null }[] | null;
   };
 }
-/** GuiMultiSliderMessage(uuid: 'str', value: 'tuple[float, ...]', container_uuid: 'str', props: 'GuiMultiSliderProps')
+/** GuiMultiSliderMessage(uuid: 'str', value: 'Tuple[float, ...]', container_uuid: 'str', props: 'GuiMultiSliderProps')
  *
  * (automatically generated)
  */
@@ -1098,11 +1098,30 @@ export interface GetRenderResponseMessage {
 }
 /** Signal that a file is about to be sent.
  *
+ * This message is used to upload files from clients to the server.
+ *
+ *
  * (automatically generated)
  */
-export interface FileTransferStart {
-  type: "FileTransferStart";
-  source_component_uuid: string | null;
+export interface FileTransferStartUpload {
+  type: "FileTransferStartUpload";
+  source_component_uuid: string;
+  transfer_uuid: string;
+  filename: string;
+  mime_type: string;
+  part_count: number;
+  size_bytes: number;
+}
+/** Signal that a file is about to be sent.
+ *
+ * This message is used to send files to clients from the server.
+ *
+ *
+ * (automatically generated)
+ */
+export interface FileTransferStartDownload {
+  type: "FileTransferStartDownload";
+  save_immediately: boolean;
   transfer_uuid: string;
   filename: string;
   mime_type: string;
@@ -1237,7 +1256,8 @@ export type Message =
   | ThemeConfigurationMessage
   | GetRenderRequestMessage
   | GetRenderResponseMessage
-  | FileTransferStart
+  | FileTransferStartUpload
+  | FileTransferStartDownload
   | FileTransferPart
   | FileTransferPartAck
   | ShareUrlRequest

--- a/src/viser/client/src/components/UploadButton.tsx
+++ b/src/viser/client/src/components/UploadButton.tsx
@@ -147,7 +147,7 @@ function useFileUpload({
     });
 
     viewer.sendMessageRef.current({
-      type: "FileTransferStart",
+      type: "FileTransferStartUpload",
       source_component_uuid: componentUuid,
       transfer_uuid: transferUuid,
       filename: file.name,


### PR DESCRIPTION
Small change for usability; by default we now show a link to sent files instead of immediately triggering a download:

https://github.com/user-attachments/assets/c75dd421-103c-45a4-bff7-34fe9bbd02d6

