### PR TITLE
Introduce `gui.add_html()`

### DIFF
--- a/docs/source/gui_handles.md
+++ b/docs/source/gui_handles.md
@@ -14,6 +14,8 @@
 
 .. autoclass:: viser.GuiMarkdownHandle()
 
+.. autoclass:: viser.GuiHtmlHandle()
+
 .. autoclass:: viser.GuiPlotlyHandle()
 
 .. autoclass:: viser.GuiTabGroupHandle()

--- a/src/viser/__init__.py
+++ b/src/viser/__init__.py
@@ -5,6 +5,7 @@ from ._gui_handles import GuiCheckboxHandle as GuiCheckboxHandle
 from ._gui_handles import GuiDropdownHandle as GuiDropdownHandle
 from ._gui_handles import GuiEvent as GuiEvent
 from ._gui_handles import GuiFolderHandle as GuiFolderHandle
+from ._gui_handles import GuiHtmlHandle as GuiHtmlHandle
 from ._gui_handles import GuiImageHandle as GuiImageHandle
 from ._gui_handles import GuiInputHandle as GuiInputHandle
 from ._gui_handles import GuiMarkdownHandle as GuiMarkdownHandle

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -41,6 +41,7 @@ from ._gui_handles import (
     GuiDropdownHandle,
     GuiEvent,
     GuiFolderHandle,
+    GuiHtmlHandle,
     GuiImageHandle,
     GuiMarkdownHandle,
     GuiModalHandle,
@@ -428,9 +429,9 @@ class GuiApi:
         if brand_color is not None:
             assert len(brand_color) in (3, 10)
             if len(brand_color) == 3:
-                assert all(map(lambda val: isinstance(val, int), brand_color)), (
-                    "All channels should be integers."
-                )
+                assert all(
+                    map(lambda val: isinstance(val, int), brand_color)
+                ), "All channels should be integers."
 
                 # RGB => HLS.
                 h, l, s = colorsys.rgb_to_hls(
@@ -631,6 +632,44 @@ class GuiApi:
         handle.content = content
         return handle
 
+    def add_html(
+        self,
+        content: str,
+        order: float | None = None,
+        visible: bool = True,
+    ) -> GuiHtmlHandle:
+        """Add HTML to the GUI.
+
+        Args:
+            content: HTML content to display.
+            order: Optional ordering, smallest values will be displayed first.
+            visible: Whether the component is visible.
+
+        Returns:
+            A handle that can be used to interact with the GUI element.
+        """
+        message = _messages.GuiHtmlMessage(
+            uuid=_make_uuid(),
+            container_uuid=self._get_container_uuid(),
+            props=_messages.GuiHtmlProps(
+                order=_apply_default_order(order),
+                content=content,
+                visible=visible,
+            ),
+        )
+        self._websock_interface.queue_message(message)
+
+        handle = GuiHtmlHandle(
+            _GuiHandleState(
+                message.uuid,
+                self,
+                None,
+                props=message.props,
+                parent_container_id=message.container_uuid,
+            ),
+        )
+        return handle
+
     def add_image(
         self,
         image: np.ndarray,
@@ -702,9 +741,9 @@ class GuiApi:
             plotly_path = (
                 Path(plotly.__file__).parent / "package_data" / "plotly.min.js"
             )
-            assert plotly_path.exists(), (
-                f"Could not find plotly.min.js at {plotly_path}."
-            )
+            assert (
+                plotly_path.exists()
+            ), f"Could not find plotly.min.js at {plotly_path}."
 
             # Send it over!
             plotly_js = plotly_path.read_text(encoding="utf-8")

--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -429,9 +429,9 @@ class GuiApi:
         if brand_color is not None:
             assert len(brand_color) in (3, 10)
             if len(brand_color) == 3:
-                assert all(
-                    map(lambda val: isinstance(val, int), brand_color)
-                ), "All channels should be integers."
+                assert all(map(lambda val: isinstance(val, int), brand_color)), (
+                    "All channels should be integers."
+                )
 
                 # RGB => HLS.
                 h, l, s = colorsys.rgb_to_hls(
@@ -741,9 +741,9 @@ class GuiApi:
             plotly_path = (
                 Path(plotly.__file__).parent / "package_data" / "plotly.min.js"
             )
-            assert (
-                plotly_path.exists()
-            ), f"Could not find plotly.min.js at {plotly_path}."
+            assert plotly_path.exists(), (
+                f"Could not find plotly.min.js at {plotly_path}."
+            )
 
             # Send it over!
             plotly_js = plotly_path.read_text(encoding="utf-8")

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -37,6 +37,7 @@ from ._messages import (
     GuiCloseModalMessage,
     GuiDropdownProps,
     GuiFolderProps,
+    GuiHtmlProps,
     GuiImageProps,
     GuiMarkdownProps,
     GuiMultiSliderProps,
@@ -794,6 +795,10 @@ class GuiMarkdownHandle(_GuiHandle[None], GuiMarkdownProps):
     def content(self, content: str) -> None:
         self._content = content
         self._markdown = _parse_markdown(content, self._image_root)
+
+
+class GuiHtmlHandle(_GuiHandle[None], GuiHtmlProps):
+    """Handling for updating and removing HTML elements."""
 
 
 class GuiPlotlyHandle(_GuiHandle[None], GuiPlotlyProps):

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -867,6 +867,22 @@ class GuiMarkdownMessage(_CreateGuiComponentMessage):
 
 
 @dataclasses.dataclass
+class GuiHtmlProps:
+    order: float
+    """Order value for arranging GUI elements. Synchronized automatically when assigned."""
+    content: str
+    """HTML content to be displayed. Synchronized automatically when assigned."""
+    visible: bool
+    """Visibility state of the markdown element. Synchronized automatically when assigned."""
+
+
+@dataclasses.dataclass
+class GuiHtmlMessage(_CreateGuiComponentMessage):
+    container_uuid: str
+    props: GuiHtmlProps
+
+
+@dataclasses.dataclass
 class GuiProgressBarProps:
     order: float
     """Order value for arranging GUI elements. Synchronized automatically when assigned."""

--- a/src/viser/client/src/ControlPanel/Generated.tsx
+++ b/src/viser/client/src/ControlPanel/Generated.tsx
@@ -23,6 +23,7 @@ import MultiSliderComponent from "../components/MultiSlider";
 import UploadButtonComponent from "../components/UploadButton";
 import ProgressBarComponent from "../components/ProgressBar";
 import ImageComponent from "../components/Image";
+import HtmlComponent from "../components/Html";
 
 /** Root of generated inputs. */
 export default function GeneratedGuiContainer({
@@ -101,6 +102,8 @@ function GeneratedInput(props: { guiUuid: string }) {
       return <TabGroupComponent {...conf} />;
     case "GuiMarkdownMessage":
       return <MarkdownComponent {...conf} />;
+    case "GuiHtmlMessage":
+      return <HtmlComponent {...conf} />;
     case "GuiPlotlyMessage":
       return <PlotlyComponent {...conf} />;
     case "GuiImageMessage":

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -354,6 +354,16 @@ export interface GuiMarkdownMessage {
   container_uuid: string;
   props: { order: number; _markdown: string; visible: boolean };
 }
+/** GuiHtmlMessage(uuid: 'str', container_uuid: 'str', props: 'GuiHtmlProps')
+ *
+ * (automatically generated)
+ */
+export interface GuiHtmlMessage {
+  type: "GuiHtmlMessage";
+  uuid: string;
+  container_uuid: string;
+  props: { order: number; content: string; visible: boolean };
+}
 /** GuiProgressBarMessage(uuid: 'str', value: 'float', container_uuid: 'str', props: 'GuiProgressBarProps')
  *
  * (automatically generated)
@@ -1188,6 +1198,7 @@ export type Message =
   | RemoveSceneNodeMessage
   | GuiFolderMessage
   | GuiMarkdownMessage
+  | GuiHtmlMessage
   | GuiProgressBarMessage
   | GuiPlotlyMessage
   | GuiImageMessage
@@ -1270,6 +1281,7 @@ export type SceneNodeMessage =
 export type GuiComponentMessage =
   | GuiFolderMessage
   | GuiMarkdownMessage
+  | GuiHtmlMessage
   | GuiProgressBarMessage
   | GuiPlotlyMessage
   | GuiImageMessage
@@ -1319,6 +1331,7 @@ export function isSceneNodeMessage(
 const typeSetGuiComponentMessage = new Set([
   "GuiFolderMessage",
   "GuiMarkdownMessage",
+  "GuiHtmlMessage",
   "GuiProgressBarMessage",
   "GuiPlotlyMessage",
   "GuiImageMessage",

--- a/src/viser/client/src/components/Html.tsx
+++ b/src/viser/client/src/components/Html.tsx
@@ -1,0 +1,8 @@
+import { GuiHtmlMessage } from "../WebsocketMessages";
+
+function HtmlComponent({ props }: GuiHtmlMessage) {
+  if (!props.visible) return <></>;
+  return <div dangerouslySetInnerHTML={{ __html: props.content }} />;
+}
+
+export default HtmlComponent;


### PR DESCRIPTION
Useful for basic things like adding videos to the GUI:

```python
import base64
from pathlib import Path

import viser

video_bytes = Path("some_video.mp4").read_bytes()

# Convert video into an HTML5 <video /> tag with a data URL.
html = f'<video style="max-width: 100%;"><source src="data:video/mp4;base64,{base64.b64encode(video_bytes).decode()}" type="video/mp4" /></video>'

server = viser.ViserServer()
server.gui.add_html(html)
server.sleep_forever()
```