### PR TITLE
Fix Python 3.8 bugs + patch tests

### DIFF
--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -981,7 +981,7 @@ class GuiCloseModalMessage(Message):
 
 @dataclasses.dataclass
 class GuiButtonProps(GuiBaseProps):
-    color: Color | None
+    color: Optional[Color]
     """Color of the button. Synchronized automatically when assigned."""
     _icon_html: Optional[str]
     """(Private) HTML string for the icon to be displayed on the button. Synchronized automatically when assigned."""
@@ -996,9 +996,9 @@ class GuiButtonMessage(_CreateGuiComponentMessage):
 
 @dataclasses.dataclass
 class GuiUploadButtonProps(GuiBaseProps):
-    color: Color | None
+    color: Optional[Color]
     """Color of the upload button. Synchronized automatically when assigned."""
-    _icon_html: str | None
+    _icon_html: Optional[str]
     """(Private) HTML string for the icon to be displayed on the upload button. Synchronized automatically when assigned."""
     mime_type: str
     """MIME type of the files that can be uploaded. Synchronized automatically when assigned."""
@@ -1045,7 +1045,7 @@ class GuiMultiSliderProps(GuiBaseProps):
     """Number of decimal places to display for the multi-slider values. Synchronized automatically when assigned."""
     fixed_endpoints: bool
     """If True, the first and last handles cannot be moved. Synchronized automatically when assigned."""
-    _marks: Tuple[GuiSliderMark, ...] | None
+    _marks: Optional[Tuple[GuiSliderMark, ...]]
     """(Private) Optional tuple of GuiSliderMark objects to display custom marks on the multi-slider. Synchronized automatically when assigned."""
 
 
@@ -1301,7 +1301,7 @@ class CubicBezierSplineProps:
     """Width of the spline line. Synchronized automatically when assigned."""
     color: Tuple[int, int, int]
     """Color of the spline as RGB integers. Synchronized automatically when assigned."""
-    segments: int | None
+    segments: Optional[int]
     """Number of segments to divide the spline into. Synchronized automatically when assigned."""
 
 

--- a/tests/test_message_annotations.py
+++ b/tests/test_message_annotations.py
@@ -1,3 +1,4 @@
+from dataclasses import fields, is_dataclass
 from typing import get_type_hints
 
 from viser.infra._messages import Message
@@ -9,8 +10,17 @@ def test_get_annotations() -> None:
     This is to guard against use of Python annotations that can't be inspected at runtime.
     We could also use `eval_type_backport`: https://github.com/alexmojaki/eval_type_backport
     """
-    for cls in Message.get_subclasses():
+
+    def recursive_get_type_hints(cls: type) -> None:
         try:
-            get_type_hints(cls)
+            hints = get_type_hints(cls)
         except TypeError as e:
-            raise AssertionError(f"Error reading type hints for {cls}") from e
+            raise TypeError(f"Failed to get type hints for {cls}") from e
+
+        assert hints is not None
+        for hint in hints.values():
+            if is_dataclass(hint):
+                recursive_get_type_hints(hint)  # type: ignore
+
+    for cls in Message.get_subclasses():
+        recursive_get_type_hints(cls)


### PR DESCRIPTION
GUI buttons, sliders, and cubic beziers were causing runtime errors in Python 3.8. (thanks @beckyfeng08!)