### PR TITLE
Fix package name in error message

### DIFF
--- a/src/viser/extras/_record3d.py
+++ b/src/viser/extras/_record3d.py
@@ -15,7 +15,7 @@ from scipy.spatial.transform import Rotation
 try:
     import liblzfse
 except ImportError:
-    print("liblzfse is missing. Please install with `pip install liblzfse`.")
+    print("liblzfse is missing. Please install with `pip install pyliblzfse`.")
     sys.exit(1)
 
 


### PR DESCRIPTION
Thanks for the great tool! I was just trying it out and ran into the error message:

```
"liblzfse is missing. Please install with `pip install liblzfse`."
```

However, the correct PyPi package name is actually `pyliblzfse`: https://pypi.org/project/pyliblzfse/