### PR TITLE
API refinements for shadows

### DIFF
--- a/docs/source/examples/06_mesh.rst
+++ b/docs/source/examples/06_mesh.rst
@@ -18,7 +18,6 @@ Visualize a mesh. To get the demo data, see ``./assets/download_dragon_mesh.sh``
 
         import numpy as np
         import trimesh
-
         import viser
         import viser.transforms as tf
 
@@ -40,9 +39,15 @@ Visualize a mesh. To get the demo data, see ``./assets/download_dragon_mesh.sh``
         )
         server.scene.add_mesh_trimesh(
             name="/trimesh",
-            mesh=mesh.smoothed(),
+            mesh=mesh,
             wxyz=tf.SO3.from_x_radians(np.pi / 2).wxyz,
             position=(0.0, 5.0, 0.0),
+        )
+        grid = server.scene.add_grid(
+            "grid",
+            width=20.0,
+            height=20.0,
+            position=np.array([0.0, 0.0, -2.0]),
         )
 
         while True:

--- a/docs/source/examples/08_smpl_visualizer.rst
+++ b/docs/source/examples/08_smpl_visualizer.rst
@@ -87,7 +87,6 @@ See here for download instructions:
             server.scene.set_up_direction("+y")
             server.gui.configure_theme(control_layout="collapsible")
 
-            server.scene.enable_default_lights(cast_shadow=True)
             server.scene.add_grid("/grid", position=(0.0, -1.3, 0.0), plane="xz")
 
             # Main loop. We'll read pose/shape from the GUI elements, compute the mesh,

--- a/docs/source/examples/09_urdf_visualizer.rst
+++ b/docs/source/examples/09_urdf_visualizer.rst
@@ -81,7 +81,6 @@ and viser. It can also take a path to a local URDF file as input.
         ) -> None:
             # Start viser server.
             server = viser.ViserServer()
-            server.scene.enable_default_lights(cast_shadow=True)
 
             # Load URDF.
             #

--- a/docs/source/examples/11_colmap_visualizer.rst
+++ b/docs/source/examples/11_colmap_visualizer.rst
@@ -48,8 +48,6 @@ Visualize COLMAP sparse reconstruction outputs. To get demo data, see ``./assets
             server = viser.ViserServer()
             server.gui.configure_theme(titlebar_content=None, control_layout="collapsible")
 
-            server.scene.enable_default_lights(cast_shadow=True)
-
             # Load the colmap info.
             cameras = read_cameras_binary(colmap_path / "cameras.bin")
             images = read_images_binary(colmap_path / "images.bin")

--- a/docs/source/examples/25_smpl_visualizer_skinned.rst
+++ b/docs/source/examples/25_smpl_visualizer_skinned.rst
@@ -25,7 +25,6 @@ See here for download instructions:
 
         import numpy as np
         import tyro
-
         import viser
         import viser.transforms as tf
 
@@ -106,6 +105,7 @@ See here for download instructions:
                 wireframe=gui_elements.gui_wireframe.value,
                 color=gui_elements.gui_rgb.value,
             )
+            server.scene.add_grid("/grid", position=(0.0, -1.3, 0.0), plane="xz")
 
             while True:
                 # Do nothing if no change.

--- a/docs/source/examples/26_lighting.rst
+++ b/docs/source/examples/26_lighting.rst
@@ -99,12 +99,12 @@ Example adding lights and enabling shadow rendering.
             )
 
             gui_default_lights.on_update(
-                lambda _: server.scene.enable_default_lights(
+                lambda _: server.scene.configure_default_lights(
                     gui_default_lights.value, gui_default_shadows.value
                 )
             )
             gui_default_shadows.on_update(
-                lambda _: server.scene.enable_default_lights(
+                lambda _: server.scene.configure_default_lights(
                     gui_default_lights.value, gui_default_shadows.value
                 )
             )

--- a/examples/06_mesh.py
+++ b/examples/06_mesh.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import numpy as np
 import trimesh
+
 import viser
 import viser.transforms as tf
 

--- a/examples/06_mesh.py
+++ b/examples/06_mesh.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 import numpy as np
 import trimesh
-
 import viser
 import viser.transforms as tf
 
@@ -30,9 +29,15 @@ server.scene.add_mesh_simple(
 )
 server.scene.add_mesh_trimesh(
     name="/trimesh",
-    mesh=mesh.smoothed(),
+    mesh=mesh,
     wxyz=tf.SO3.from_x_radians(np.pi / 2).wxyz,
     position=(0.0, 5.0, 0.0),
+)
+grid = server.scene.add_grid(
+    "grid",
+    width=20.0,
+    height=20.0,
+    position=np.array([0.0, 0.0, -2.0]),
 )
 
 while True:

--- a/examples/08_smpl_visualizer.py
+++ b/examples/08_smpl_visualizer.py
@@ -77,7 +77,6 @@ def main(model_path: Path) -> None:
     server.scene.set_up_direction("+y")
     server.gui.configure_theme(control_layout="collapsible")
 
-    server.scene.enable_default_lights(cast_shadow=True)
     server.scene.add_grid("/grid", position=(0.0, -1.3, 0.0), plane="xz")
 
     # Main loop. We'll read pose/shape from the GUI elements, compute the mesh,

--- a/examples/09_urdf_visualizer.py
+++ b/examples/09_urdf_visualizer.py
@@ -69,7 +69,6 @@ def main(
 ) -> None:
     # Start viser server.
     server = viser.ViserServer()
-    server.scene.enable_default_lights(cast_shadow=True)
 
     # Load URDF.
     #

--- a/examples/11_colmap_visualizer.py
+++ b/examples/11_colmap_visualizer.py
@@ -38,8 +38,6 @@ def main(
     server = viser.ViserServer()
     server.gui.configure_theme(titlebar_content=None, control_layout="collapsible")
 
-    server.scene.enable_default_lights(cast_shadow=True)
-
     # Load the colmap info.
     cameras = read_cameras_binary(colmap_path / "cameras.bin")
     images = read_images_binary(colmap_path / "images.bin")

--- a/examples/25_smpl_visualizer_skinned.py
+++ b/examples/25_smpl_visualizer_skinned.py
@@ -20,7 +20,6 @@ from typing import List, Tuple
 
 import numpy as np
 import tyro
-
 import viser
 import viser.transforms as tf
 
@@ -101,6 +100,7 @@ def main(model_path: Path) -> None:
         wireframe=gui_elements.gui_wireframe.value,
         color=gui_elements.gui_rgb.value,
     )
+    server.scene.add_grid("/grid", position=(0.0, -1.3, 0.0), plane="xz")
 
     while True:
         # Do nothing if no change.

--- a/examples/25_smpl_visualizer_skinned.py
+++ b/examples/25_smpl_visualizer_skinned.py
@@ -20,6 +20,7 @@ from typing import List, Tuple
 
 import numpy as np
 import tyro
+
 import viser
 import viser.transforms as tf
 

--- a/examples/26_lighting.py
+++ b/examples/26_lighting.py
@@ -89,12 +89,12 @@ def main() -> None:
     )
 
     gui_default_lights.on_update(
-        lambda _: server.scene.enable_default_lights(
+        lambda _: server.scene.configure_default_lights(
             gui_default_lights.value, gui_default_shadows.value
         )
     )
     gui_default_shadows.on_update(
-        lambda _: server.scene.enable_default_lights(
+        lambda _: server.scene.configure_default_lights(
             gui_default_lights.value, gui_default_shadows.value
         )
     )

--- a/examples/experimental/gaussian_splats.py
+++ b/examples/experimental/gaussian_splats.py
@@ -121,7 +121,6 @@ def main(splat_paths: tuple[Path, ...]) -> None:
             [0.0, -1.0, 0.0]
         )
 
-    handles = []
     for i, splat_path in enumerate(splat_paths):
         if splat_path.suffix == ".splat":
             splat_data = load_splat_file(splat_path, center=True)
@@ -138,7 +137,6 @@ def main(splat_paths: tuple[Path, ...]) -> None:
             opacities=splat_data["opacities"],
             covariances=splat_data["covariances"],
         )
-        handles.append(gs_handle)
 
         remove_button = server.gui.add_button(f"Remove splat object {i}")
 
@@ -148,9 +146,7 @@ def main(splat_paths: tuple[Path, ...]) -> None:
             remove_button.remove()
 
     while True:
-        time.sleep(3.0)
-        for h in handles[1:]:
-            h.buffer = handles[0].buffer
+        time.sleep(10.0)
 
 
 if __name__ == "__main__":

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -241,6 +241,10 @@ class CameraFrustumProps:
     """Format of the provided image ('image/jpeg' or 'image/png'). Synchronized automatically when assigned."""
     _image_data: Optional[bytes]
     """Optional image to be displayed on the frustum. Synchronized automatically when assigned."""
+    cast_shadow: bool
+    """Whether or not to cast shadows. Synchronized automatically when assigned."""
+    receive_shadow: bool
+    """Whether or not to receive shadows. Synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -256,6 +260,10 @@ class GlbProps:
     """A binary payload containing the GLB data. Synchronized automatically when assigned."""
     scale: float
     """A scale for resizing the GLB asset. Synchronized automatically when assigned."""
+    cast_shadow: bool
+    """Whether or not to cast shadows. Synchronized automatically when assigned."""
+    receive_shadow: bool
+    """Whether or not to receive shadows. Synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass
@@ -577,6 +585,10 @@ class MeshProps:
     """Side of the surface to render. Synchronized automatically when assigned."""
     material: Literal["standard", "toon3", "toon5"]
     """Material type of the mesh. Synchronized automatically when assigned."""
+    cast_shadow: bool
+    """Whether or not to cast shadows. Synchronized automatically when assigned."""
+    receive_shadow: bool
+    """Whether or not to receive shadows. Synchronized automatically when assigned."""
 
     def __post_init__(self):
         # Check shapes.
@@ -605,6 +617,10 @@ class SkinnedMeshProps(MeshProps):
     """Array of skin indices. Should have shape (V, 4). Synchronized automatically when assigned."""
     skin_weights: npt.NDArray[np.float32]
     """Array of skin weights. Should have shape (V, 4). Synchronized automatically when assigned."""
+    cast_shadow: bool
+    """Whether or not to cast shadows. Synchronized automatically when assigned."""
+    receive_shadow: bool
+    """Whether or not to receive shadows. Synchronized automatically when assigned."""
 
     def __post_init__(self):
         # Check shapes.
@@ -789,6 +805,10 @@ class ImageProps:
     """Width at which the image should be rendered in the scene. Synchronized automatically when assigned."""
     render_height: float
     """Height at which the image should be rendered in the scene. Synchronized automatically when assigned."""
+    cast_shadow: bool
+    """Whether or not to cast shadows. Synchronized automatically when assigned."""
+    receive_shadow: bool
+    """Whether or not to receive shadows. Synchronized automatically when assigned."""
 
 
 @dataclasses.dataclass

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -106,9 +106,9 @@ TVector = TypeVar("TVector", bound=tuple)
 
 def cast_vector(vector: TVector | np.ndarray, length: int) -> TVector:
     if not isinstance(vector, tuple):
-        assert cast(np.ndarray, vector).shape == (
-            length,
-        ), f"Expected vector of shape {(length,)}, but got {vector.shape} instead"
+        assert cast(np.ndarray, vector).shape == (length,), (
+            f"Expected vector of shape {(length,)}, but got {vector.shape} instead"
+        )
     return cast(TVector, tuple(map(float, vector)))
 
 
@@ -1087,9 +1087,9 @@ class SceneApi:
             Handle for manipulating scene node.
         """
         colors_cast = colors_to_uint8(np.asarray(colors))
-        assert (
-            len(points.shape) == 2 and points.shape[-1] == 3
-        ), "Shape of points should be (N, 3)."
+        assert len(points.shape) == 2 and points.shape[-1] == 3, (
+            "Shape of points should be (N, 3)."
+        )
         assert colors_cast.shape in {
             points.shape,
             (3,),

--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -760,6 +760,7 @@ class ViserServer(_BackwardsCompatibilityShim if not TYPE_CHECKING else object):
             self.request_share_url()
 
         self.scene.reset()
+        self.scene.set_up_direction("+z")
         self.gui.reset()
         self.gui.set_panel_label(label)
 

--- a/src/viser/client/src/CsmDirectionalLight.tsx
+++ b/src/viser/client/src/CsmDirectionalLight.tsx
@@ -137,7 +137,7 @@ function ShadowCsmLight({
   lightIntensity,
   cascades,
   fade,
-  position,
+  position = [0, -1, 0],
   shadowBias,
   lightFar,
   lightMargin,

--- a/src/viser/client/src/CsmDirectionalLight.tsx
+++ b/src/viser/client/src/CsmDirectionalLight.tsx
@@ -84,18 +84,18 @@ function updateMaterialsInScene(scene: Object3D): void {
 
 // Modified approach that uses conditional rendering with proper mount/unmount.
 export function CsmDirectionalLight({
-  maxFar = 50,
+  maxFar = 10,
   shadowMapSize = 1024,
   lightIntensity = 0.25,
   cascades = 3,
-  fade,
-  position = [1, 1, 1], // Default position in space
-  shadowBias = 0.000001,
-  lightFar,
-  lightMargin,
-  lightNear,
-  mode,
-  color,
+  fade = true,
+  position = [1, 1, 1],
+  shadowBias = -0.00001,
+  lightFar = 2000,
+  lightMargin = 200,
+  lightNear = 0.0001,
+  mode = "practical",
+  color = 0xffffff,
   castShadow = true,
 }: CsmDirectionalLightProps) {
   // Standard directional light for the non-shadow case.
@@ -132,13 +132,13 @@ export function CsmDirectionalLight({
 
 // Separate component for the shadow-casting implementation to avoid hook conditionals.
 function ShadowCsmLight({
-  maxFar = 50,
-  shadowMapSize = 1024,
-  lightIntensity = 0.25,
-  cascades = 2,
+  maxFar,
+  shadowMapSize,
+  lightIntensity,
+  cascades,
   fade,
-  position = [0.0, 0.0, 0.0],
-  shadowBias = 0.000001,
+  position,
+  shadowBias,
   lightFar,
   lightMargin,
   lightNear,

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -285,18 +285,7 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
     // Add a camera frustum.
     case "CameraFrustumMessage": {
       return {
-        makeObject: (ref) => (
-          <CameraFrustum
-            ref={ref}
-            fov={message.props.fov}
-            aspect={message.props.aspect}
-            scale={message.props.scale}
-            lineWidth={message.props.line_width}
-            color={rgbToInt(message.props.color)}
-            imageBinary={message.props._image_data}
-            imageMediaType={message.props.image_media_type}
-          />
-        ),
+        makeObject: (ref) => <CameraFrustum ref={ref} {...message} />,
       };
     }
     case "TransformControlsMessage": {
@@ -424,8 +413,10 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
         makeObject: (ref) => (
           <GlbAsset
             ref={ref}
-            glb_data={new Uint8Array(message.props.glb_data)}
+            glbData={new Uint8Array(message.props.glb_data)}
             scale={message.props.scale}
+            castShadow={message.props.cast_shadow}
+            receiveShadow={message.props.receive_shadow}
           />
         ),
       };

--- a/src/viser/client/src/SceneTreeState.tsx
+++ b/src/viser/client/src/SceneTreeState.tsx
@@ -76,7 +76,7 @@ export function useSceneTreeState(
         },
         labelVisibleFromName: {},
         enableDefaultLights: true,
-        enableDefaultLightsShadows: false,
+        enableDefaultLightsShadows: true,
         environmentMap: {
           type: "EnvironmentMapMessage",
           hdri: "city",

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -849,7 +849,7 @@ export const CameraFrustum = React.forwardRef<
         >
           <planeGeometry
             attach="geometry"
-            args={[props.aspect * y * 2, y * 2]}
+            args={[message.props.aspect * y * 2, y * 2]}
           />
           <meshBasicMaterial
             attach="material"

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -17,6 +17,8 @@ export interface CameraFrustumMessage {
     color: [number, number, number];
     image_media_type: "image/jpeg" | "image/png" | null;
     _image_data: Uint8Array | null;
+    cast_shadow: boolean;
+    receive_shadow: boolean;
   };
 }
 /** GlTF message.
@@ -26,7 +28,12 @@ export interface CameraFrustumMessage {
 export interface GlbMessage {
   type: "GlbMessage";
   name: string;
-  props: { glb_data: Uint8Array; scale: number };
+  props: {
+    glb_data: Uint8Array;
+    scale: number;
+    cast_shadow: boolean;
+    receive_shadow: boolean;
+  };
 }
 /** Coordinate frame message.
  *
@@ -218,6 +225,8 @@ export interface MeshMessage {
     flat_shading: boolean;
     side: "front" | "back" | "double";
     material: "standard" | "toon3" | "toon5";
+    cast_shadow: boolean;
+    receive_shadow: boolean;
   };
 }
 /** Skinned mesh message.
@@ -236,6 +245,8 @@ export interface SkinnedMeshMessage {
     flat_shading: boolean;
     side: "front" | "back" | "double";
     material: "standard" | "toon3" | "toon5";
+    cast_shadow: boolean;
+    receive_shadow: boolean;
     bone_wxyzs: Uint8Array;
     bone_positions: Uint8Array;
     skin_indices: Uint8Array;
@@ -276,6 +287,8 @@ export interface ImageMessage {
     _data: Uint8Array;
     render_width: number;
     render_height: number;
+    cast_shadow: boolean;
+    receive_shadow: boolean;
   };
 }
 /** Message from server->client carrying line segments information.


### PR DESCRIPTION
Some changes, in part based on feedback from @chungmin99! cc @beckyfeng08

1. Added back `cast_shadow` and `receive_shadow` properties for objects that can cast shadows. These all default to `True`.
2. `enable_default_lights()` has been renamed to `configure_default_lights()`, since the method now does more than enable/disable lights. I added a shim for backward compatibility.
3. `cast_shadow` now defaults to `True` for the default lights. I think this is a sensible default. In our next pass over the docs we should add a guide on performance for large scenes, turning off shadows can be part of that.