### PR TITLE
Make batched axes props consistent with `add_batched_axes()` signature

### DIFF
--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -299,9 +299,9 @@ class BatchedAxesMessage(_CreateSceneNodeMessage):
 
 @dataclasses.dataclass
 class BatchedAxesProps:
-    wxyzs_batched: npt.NDArray[np.float32]
+    batched_wxyzs: npt.NDArray[np.float32]
     """Float array of shape (N,4) representing quaternion rotations. Synchronized automatically when assigned."""
-    positions_batched: npt.NDArray[np.float32]
+    batched_positions: npt.NDArray[np.float32]
     """Float array of shape (N,3) representing positions. Synchronized automatically when assigned."""
     axes_length: float
     """Length of each axis. Synchronized automatically when assigned."""

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -958,8 +958,8 @@ class SceneApi:
         assert batched_wxyzs.shape == (num_axes, 4)
         assert batched_positions.shape == (num_axes, 3)
         props = _messages.BatchedAxesProps(
-            wxyzs_batched=batched_wxyzs.astype(np.float32),
-            positions_batched=batched_positions.astype(np.float32),
+            batched_wxyzs=batched_wxyzs.astype(np.float32),
+            batched_positions=batched_positions.astype(np.float32),
             axes_length=axes_length,
             axes_radius=axes_radius,
         )

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -165,21 +165,21 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
           // precise.
           <InstancedAxes
             ref={ref}
-            wxyzsBatched={
+            batchedWxyzs={
               new Float32Array(
-                message.props.wxyzs_batched.buffer.slice(
-                  message.props.wxyzs_batched.byteOffset,
-                  message.props.wxyzs_batched.byteOffset +
-                    message.props.wxyzs_batched.byteLength,
+                message.props.batched_wxyzs.buffer.slice(
+                  message.props.batched_wxyzs.byteOffset,
+                  message.props.batched_wxyzs.byteOffset +
+                    message.props.batched_wxyzs.byteLength,
                 ),
               )
             }
-            positionsBatched={
+            batchedPositions={
               new Float32Array(
-                message.props.positions_batched.buffer.slice(
-                  message.props.positions_batched.byteOffset,
-                  message.props.positions_batched.byteOffset +
-                    message.props.positions_batched.byteLength,
+                message.props.batched_positions.buffer.slice(
+                  message.props.batched_positions.byteOffset,
+                  message.props.batched_positions.byteOffset +
+                    message.props.batched_positions.byteLength,
                 ),
               )
             }

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -165,7 +165,7 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
           // precise.
           <InstancedAxes
             ref={ref}
-            batchedWxyzs={
+            batched_wxyzs={
               new Float32Array(
                 message.props.batched_wxyzs.buffer.slice(
                   message.props.batched_wxyzs.byteOffset,
@@ -174,7 +174,7 @@ function useObjectFactory(message: SceneNodeMessage | undefined): {
                 ),
               )
             }
-            batchedPositions={
+            batched_positions={
               new Float32Array(
                 message.props.batched_positions.buffer.slice(
                   message.props.batched_positions.byteOffset,

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -346,18 +346,13 @@ export const CoordinateFrame = React.forwardRef<
 export const InstancedAxes = React.forwardRef<
   THREE.Group,
   {
-    wxyzsBatched: Float32Array;
-    positionsBatched: Float32Array;
+    batched_wxyzs: Float32Array;
+    batched_positions: Float32Array;
     axes_length?: number;
     axes_radius?: number;
   }
 >(function InstancedAxes(
-  {
-    wxyzsBatched: instance_wxyzs,
-    positionsBatched: instance_positions,
-    axes_length = 0.5,
-    axes_radius = 0.0125,
-  },
+  { batched_wxyzs, batched_positions, axes_length = 0.5, axes_radius = 0.0125 },
   ref,
 ) {
   const axesRef = React.useRef<THREE.InstancedMesh>(null);
@@ -402,18 +397,18 @@ export const InstancedAxes = React.forwardRef<
     const green = new THREE.Color(0x00cc00);
     const blue = new THREE.Color(0x0000cc);
 
-    for (let i = 0; i < instance_wxyzs.length / 4; i++) {
+    for (let i = 0; i < batched_wxyzs.length / 4; i++) {
       T_world_frame.makeRotationFromQuaternion(
         tmpQuat.set(
-          instance_wxyzs[i * 4 + 1],
-          instance_wxyzs[i * 4 + 2],
-          instance_wxyzs[i * 4 + 3],
-          instance_wxyzs[i * 4 + 0],
+          batched_wxyzs[i * 4 + 1],
+          batched_wxyzs[i * 4 + 2],
+          batched_wxyzs[i * 4 + 3],
+          batched_wxyzs[i * 4 + 0],
         ),
       ).setPosition(
-        instance_positions[i * 3 + 0],
-        instance_positions[i * 3 + 1],
-        instance_positions[i * 3 + 2],
+        batched_positions[i * 3 + 0],
+        batched_positions[i * 3 + 1],
+        batched_positions[i * 3 + 2],
       );
       T_world_framex.copy(T_world_frame).multiply(T_frame_framex);
       T_world_framey.copy(T_world_frame).multiply(T_frame_framey);
@@ -429,13 +424,13 @@ export const InstancedAxes = React.forwardRef<
     }
     axesRef.current!.instanceMatrix.needsUpdate = true;
     axesRef.current!.instanceColor!.needsUpdate = true;
-  }, [instance_wxyzs, instance_positions]);
+  }, [batched_wxyzs, batched_positions]);
 
   return (
     <group ref={ref}>
       <instancedMesh
         ref={axesRef}
-        args={[cylinderGeom, material, (instance_wxyzs.length / 4) * 3]}
+        args={[cylinderGeom, material, (batched_wxyzs.length / 4) * 3]}
       >
         <OutlinesIfHovered />
       </instancedMesh>

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -61,8 +61,8 @@ export interface BatchedAxesMessage {
   type: "BatchedAxesMessage";
   name: string;
   props: {
-    wxyzs_batched: Uint8Array;
-    positions_batched: Uint8Array;
+    batched_wxyzs: Uint8Array;
+    batched_positions: Uint8Array;
     axes_length: number;
     axes_radius: number;
   };


### PR DESCRIPTION
Fixes #416. I chose to rename the props, since this is much less likely to break downstream code than renaming the arguments.

Reasonable @chungmin99?