### PR TITLE
Fix logo path and improve HTTP headers

### DIFF
--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -750,7 +750,7 @@ function ViserLogo() {
           onClick={openAbout}
           title="About Viser"
         >
-          <Image src="/logo.svg" style={{ width: "2.5em", height: "auto" }} />
+          <Image src="./logo.svg" style={{ width: "2.5em", height: "auto" }} />
         </Box>
       </Tooltip>
       <Modal

--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -477,13 +477,9 @@ class WebsockServer(WebsockMessageHandler):
             if mime_type is None:
                 mime_type = "application/octet-stream"
 
-            response_headers = {
-                "Content-Type": mime_type,
-            }
             if source_path not in file_cache:
                 file_cache[source_path] = source_path.read_bytes()
             if use_gzip:
-                response_headers["Content-Encoding"] = "gzip"
                 if source_path not in file_cache_gzipped:
                     file_cache_gzipped[source_path] = gzip.compress(
                         file_cache[source_path]
@@ -491,6 +487,12 @@ class WebsockServer(WebsockMessageHandler):
                 response_payload = file_cache_gzipped[source_path]
             else:
                 response_payload = file_cache[source_path]
+
+            response_headers = {
+                "Content-Type": mime_type,
+                "Content-Length": str(len(response_payload)),
+                "Content-Encoding": "gzip" if use_gzip else "identity",
+            }
 
             # Try to read + send over file.
             return Response(


### PR DESCRIPTION
## Summary
- Use relative path for logo to fix display in various hosting scenarios
- Add Content-Length header and always include Content-Encoding for better HTTP compliance

## Test plan
- Verify logo displays correctly when served from different paths
- Check HTTP response headers include Content-Length and Content-Encoding

🤖 Generated with [Claude Code](https://claude.ai/code)