### PR TITLE
Update @react-three/drei to ^10.0.5

### DIFF
--- a/src/viser/client/package.json
+++ b/src/viser/client/package.json
@@ -13,7 +13,7 @@
     "@mdx-js/mdx": "^3.0.1",
     "@mdx-js/react": "^3.0.1",
     "@msgpack/msgpack": "^3.0.0-beta2",
-    "@react-three/drei": "10.0.2",
+    "@react-three/drei": "^10.0.5",
     "@react-three/fiber": "9.1.0",
     "@tabler/icons-react": "^3.1.0",
     "@types/node": "^20.11.30",


### PR DESCRIPTION
## Summary
* Update @react-three/drei package from pinned version 10.0.2 to ^10.0.5
    * Was waiting on this PR: https://github.com/pmndrs/drei/pull/2390

## Test plan
* Verify that all examples continue to render correctly
* Check that no rendering artifacts or console errors appear

🤖 Generated with [Claude Code](https://claude.ai/code)