### PR TITLE
Rename set_environment_map to configure_environment_map

### DIFF
--- a/docs/source/examples/04_camera_poses.rst
+++ b/docs/source/examples/04_camera_poses.rst
@@ -47,5 +47,8 @@ Example showing how we can detect new clients and read camera poses from them.
                 print(f"\tfov: {client.camera.fov}")
                 print(f"\taspect: {client.camera.aspect}")
                 print(f"\tlast update: {client.camera.update_timestamp}")
+                print(
+                    f"\tcanvas size: {client.camera.image_width}x{client.camera.image_height}"
+                )
 
             time.sleep(2.0)

--- a/docs/source/examples/06_mesh.rst
+++ b/docs/source/examples/06_mesh.rst
@@ -18,6 +18,7 @@ Visualize a mesh. To get the demo data, see ``./assets/download_dragon_mesh.sh``
 
         import numpy as np
         import trimesh
+
         import viser
         import viser.transforms as tf
 

--- a/docs/source/examples/11_colmap_visualizer.rst
+++ b/docs/source/examples/11_colmap_visualizer.rst
@@ -70,11 +70,6 @@ Visualize COLMAP sparse reconstruction outputs. To get demo data, see ``./assets
                 average_up /= np.linalg.norm(average_up)
                 server.scene.set_up_direction((average_up[0], average_up[1], average_up[2]))
 
-            # Get transformed z-coordinates and place grid at 5th percentile height.
-            transformed_z = points[..., 2]
-            grid_height = float(np.percentile(transformed_z, 5))
-            server.scene.add_grid(name="/grid", position=(0.0, 0.0, grid_height))
-
             @gui_reset_up.on_click
             def _(event: viser.GuiEvent) -> None:
                 client = event.client
@@ -172,8 +167,9 @@ Visualize COLMAP sparse reconstruction outputs. To get demo data, see ``./assets
             @gui_points.on_update
             def _(_) -> None:
                 point_mask = np.random.choice(points.shape[0], gui_points.value, replace=False)
-                point_cloud.points = points[point_mask]
-                point_cloud.colors = colors[point_mask]
+                with server.atomic():
+                    point_cloud.points = points[point_mask]
+                    point_cloud.colors = colors[point_mask]
 
             @gui_frames.on_update
             def _(_) -> None:

--- a/docs/source/examples/25_smpl_visualizer_skinned.rst
+++ b/docs/source/examples/25_smpl_visualizer_skinned.rst
@@ -25,6 +25,7 @@ See here for download instructions:
 
         import numpy as np
         import tyro
+
         import viser
         import viser.transforms as tf
 

--- a/docs/source/examples/26_lighting.rst
+++ b/docs/source/examples/26_lighting.rst
@@ -201,7 +201,7 @@ Example adding lights and enabling shadow rendering.
                 )
 
             def update_environment_map(_) -> None:
-                server.scene.set_environment_map(
+                server.scene.configure_environment_map(
                     gui_env_preset.value if gui_env_preset.value != "None" else None,
                     background=gui_background.value,
                     background_blurriness=gui_bg_blurriness.value,

--- a/examples/26_lighting.py
+++ b/examples/26_lighting.py
@@ -191,7 +191,7 @@ def main() -> None:
         )
 
     def update_environment_map(_) -> None:
-        server.scene.set_environment_map(
+        server.scene.configure_environment_map(
             gui_env_preset.value if gui_env_preset.value != "None" else None,
             background=gui_background.value,
             background_blurriness=gui_bg_blurriness.value,

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -486,7 +486,7 @@ class SceneApi:
         )
         return SpotLightHandle._make(self, message, name, wxyz, position, visible)
 
-    def set_environment_map(
+    def configure_environment_map(
         self,
         hdri: None
         | Literal[
@@ -518,7 +518,7 @@ class SceneApi:
             0.0,
         ),
     ) -> None:
-        """Set the environment map for the scene. This will set some lights and background.
+        """Configure the environment map for the scene. This will set some lights and background.
 
         Args:
             hdri: Preset HDRI environment to use.
@@ -549,7 +549,7 @@ class SceneApi:
         """Configure the default lights in the scene.
 
         This does not affect lighting from the environment map. To turn these off,
-        see :meth:`SceneApi.set_environment_map()`.
+        see :meth:`SceneApi.configure_environment_map()`.
 
         Args:
             enabled: Whether or not the lights are enabled.
@@ -567,6 +567,13 @@ class SceneApi:
                 DeprecationWarning,
             )
             return self.configure_default_lights(*args, **kwargs)
+
+        def set_environment_map(self, *args, **kwargs) -> None:
+            warnings.warn(
+                "The 'set_environment_map' method has been renamed to 'configure_environment_map'.",
+                DeprecationWarning,
+            )
+            return self.configure_environment_map(*args, **kwargs)
 
     def add_glb(
         self,


### PR DESCRIPTION
## Summary
- Renames `set_environment_map` method to `configure_environment_map` for consistency with `configure_theme`, `configure_default_lights`
- Adds backward compatibility shim with deprecation warning
- Updates docstrings and example usages
- Updates documentation files

This mirrors the change made in #412 where `enable_default_lights` was renamed to `configure_default_lights`.

🤖 Generated with [Claude Code](https://claude.ai/code)