### PR TITLE
Replace `point_ball_norm` prop with `point_shape` for consistency

### DIFF
--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -393,8 +393,8 @@ class PointCloudProps:
     """Colors of points. Should have shape (N, 3) or (3,). Synchronized automatically when assigned."""
     point_size: float
     """Size of each point. Synchronized automatically when assigned."""
-    point_ball_norm: float
-    """Norm value determining the shape of each point. Synchronized automatically when assigned."""
+    point_shape: Literal["square", "diamond", "circle", "rounded", "sparkle"]
+    """Shape to draw each point. Synchronized automatically when assigned."""
     precision: Literal["float16", "float32"]
     """Precision of the point cloud. Assignments to `points` are automatically casted
     based on the current precision value. Updates to `points` should therefore happen

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -108,9 +108,9 @@ TVector = TypeVar("TVector", bound=tuple)
 
 def cast_vector(vector: TVector | np.ndarray, length: int) -> TVector:
     if not isinstance(vector, tuple):
-        assert cast(np.ndarray, vector).shape == (
-            length,
-        ), f"Expected vector of shape {(length,)}, but got {vector.shape} instead"
+        assert cast(np.ndarray, vector).shape == (length,), (
+            f"Expected vector of shape {(length,)}, but got {vector.shape} instead"
+        )
     return cast(TVector, tuple(map(float, vector)))
 
 
@@ -1099,9 +1099,9 @@ class SceneApi:
             Handle for manipulating scene node.
         """
         colors_cast = colors_to_uint8(np.asarray(colors))
-        assert (
-            len(points.shape) == 2 and points.shape[-1] == 3
-        ), "Shape of points should be (N, 3)."
+        assert len(points.shape) == 2 and points.shape[-1] == 3, (
+            "Shape of points should be (N, 3)."
+        )
         assert colors_cast.shape in {
             points.shape,
             (3,),

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -108,9 +108,9 @@ TVector = TypeVar("TVector", bound=tuple)
 
 def cast_vector(vector: TVector | np.ndarray, length: int) -> TVector:
     if not isinstance(vector, tuple):
-        assert cast(np.ndarray, vector).shape == (length,), (
-            f"Expected vector of shape {(length,)}, but got {vector.shape} instead"
-        )
+        assert cast(np.ndarray, vector).shape == (
+            length,
+        ), f"Expected vector of shape {(length,)}, but got {vector.shape} instead"
     return cast(TVector, tuple(map(float, vector)))
 
 
@@ -1099,9 +1099,9 @@ class SceneApi:
             Handle for manipulating scene node.
         """
         colors_cast = colors_to_uint8(np.asarray(colors))
-        assert len(points.shape) == 2 and points.shape[-1] == 3, (
-            "Shape of points should be (N, 3)."
-        )
+        assert (
+            len(points.shape) == 2 and points.shape[-1] == 3
+        ), "Shape of points should be (N, 3)."
         assert colors_cast.shape in {
             points.shape,
             (3,),
@@ -1117,13 +1117,7 @@ class SceneApi:
                 ),
                 colors=colors_cast,
                 point_size=point_size,
-                point_ball_norm={
-                    "square": float("inf"),
-                    "diamond": 1.0,
-                    "circle": 2.0,
-                    "rounded": 3.0,
-                    "sparkle": 0.6,
-                }[point_shape],
+                point_shape=point_shape,
                 precision=precision,
             ),
         )

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -141,8 +141,14 @@ export const PointCloud = React.forwardRef<THREE.Points, PointCloudMessage>(
     // Update material properties with point_ball_norm
     React.useEffect(() => {
       material.uniforms.scale.value = 10.0;
-      material.uniforms.point_ball_norm.value = props.point_ball_norm;
-    }, [props.point_ball_norm, material]);
+      material.uniforms.point_ball_norm.value = {
+        square: Infinity,
+        diamond: 1.0,
+        circle: 2.0,
+        rounded: 3.0,
+        sparkle: 0.6,
+      }[props.point_shape];
+    }, [props.point_shape, material]);
 
     const rendererSize = new THREE.Vector2();
     useFrame(() => {

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -123,7 +123,7 @@ export interface PointCloudMessage {
     points: Uint8Array;
     colors: Uint8Array;
     point_size: number;
-    point_ball_norm: number;
+    point_shape: "square" | "diamond" | "circle" | "rounded" | "sparkle";
     precision: "float16" | "float32";
   };
 }


### PR DESCRIPTION
## Summary
- Replace `point_ball_norm` with `point_shape` Literal type in PointCloudProps for consistency with `add_point_cloud` API
- Improved the API consistency by using the same parameter names and types across related functions
- Updated client code to map from shape names to numerical values

## Test plan
- Run Python examples that use the point cloud functionality
- Verify visualization of different point shapes works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)