### PR TITLE
Fix visibility toggle edge case for `unmountWhenInvisible=true`

### DIFF
--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -794,7 +794,7 @@ export function SceneNodeThreeObject(props: {
   });
 
   if (objNode === undefined || unmount) {
-    return <>{children}</>;
+    return null;
   } else {
     return (
       <>


### PR DESCRIPTION
Fixes `Cannot read properties of undefined (reading 'count')` error when elements were portaled into nonexistent parents.