### PR TITLE
Fix regression for broadcasted point cloud shape

### DIFF
--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -402,7 +402,8 @@ class PointCloudProps:
 
     def __post_init__(self):
         # Check shapes.
-        # assert self.points.shape == self.colors.shape
+        assert len(self.points.shape) == 2
+        assert self.colors.shape in ((3,), (self.points.shape[0], 3))
         assert self.points.shape[-1] == 3
 
         # Check dtypes.

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -402,7 +402,7 @@ class PointCloudProps:
 
     def __post_init__(self):
         # Check shapes.
-        assert self.points.shape == self.colors.shape
+        # assert self.points.shape == self.colors.shape
         assert self.points.shape[-1] == 3
 
         # Check dtypes.

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -121,9 +121,9 @@ export const PointCloud = React.forwardRef<THREE.Points, PointCloudMessage>(
       } else {
         material.vertexColors = false;
         material.uniforms.uniformColor.value = new THREE.Color(
-          props.colors[0],
-          props.colors[1],
-          props.colors[2],
+          props.colors[0] / 255.0,
+          props.colors[1] / 255.0,
+          props.colors[2] / 255.0,
         );
       }
 


### PR DESCRIPTION
## Summary
- Remove assertion in PointCloudProps that prevented single-color point clouds
- Fix color normalization in ThreeAssets.tsx to properly display RGB colors (divide by 255.0)

## Test plan
- Verify that point clouds with a single color (shape mismatch between points and colors) work correctly
- Confirm that point cloud colors display with correct RGB values

🤖 Generated with [Claude Code](https://claude.ai/code)

Fixes #444