### PR TITLE
Fix point cloud shader for Firefox

### DIFF
--- a/src/viser/client/src/ControlPanel/GuiState.tsx
+++ b/src/viser/client/src/ControlPanel/GuiState.tsx
@@ -153,12 +153,13 @@ export function useGuiState(initialServer: string) {
 
             // This feels brittle, could be cleaned up...
             state.theme = cleanGuiState.theme;
-            state.shareUrl = null;
-            state.guiUuidSetFromContainerUuid = {};
-            state.modals = [];
-            state.guiOrderFromUuid = {};
-            state.guiConfigFromUuid = {};
-            state.uploadsInProgress = {};
+            state.shareUrl = cleanGuiState.shareUrl;
+            state.guiUuidSetFromContainerUuid =
+              cleanGuiState.guiUuidSetFromContainerUuid;
+            state.modals = cleanGuiState.modals;
+            state.guiOrderFromUuid = cleanGuiState.guiOrderFromUuid;
+            state.guiConfigFromUuid = cleanGuiState.guiConfigFromUuid;
+            state.uploadsInProgress = cleanGuiState.uploadsInProgress;
           }),
         updateUploadState: (state) =>
           set((globalState) => {

--- a/src/viser/client/src/ControlPanel/GuiState.tsx
+++ b/src/viser/client/src/ControlPanel/GuiState.tsx
@@ -152,7 +152,6 @@ export function useGuiState(initialServer: string) {
             // state.label = cleanGuiState.label;
 
             // This feels brittle, could be cleaned up...
-            state.theme = cleanGuiState.theme;
             state.shareUrl = cleanGuiState.shareUrl;
             state.guiUuidSetFromContainerUuid =
               cleanGuiState.guiUuidSetFromContainerUuid;

--- a/src/viser/client/src/ControlPanel/GuiState.tsx
+++ b/src/viser/client/src/ControlPanel/GuiState.tsx
@@ -152,6 +152,7 @@ export function useGuiState(initialServer: string) {
             // state.label = cleanGuiState.label;
 
             // This feels brittle, could be cleaned up...
+            state.theme = cleanGuiState.theme;
             state.shareUrl = null;
             state.guiUuidSetFromContainerUuid = {};
             state.modals = [];

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -44,7 +44,6 @@ const PointCloudMaterial = /* @__PURE__ */ shaderMaterial(
   `varying vec3 vPosition;
   varying vec3 vColor;
   uniform float point_ball_norm;
-  uniform vec3 uniformColor;
 
   void main() {
       if (point_ball_norm < 1000.0) {


### PR DESCRIPTION
Our point cloud shader was broken in Firefox. This was related to recent changes in #420 and #445; releases on pip aren't affected.

Closes #453; thanks @tuning12!