### PR TITLE
Transform controls callbacks: API consistency, add `on_drag_start` and `on_drag_end`

### DIFF
--- a/docs/source/events.rst
+++ b/docs/source/events.rst
@@ -9,3 +9,5 @@ when events like clicks or GUI updates are triggered.
 .. autoclass:: viser.SceneNodePointerEvent()
 
 .. autoclass:: viser.GuiEvent()
+
+.. autoclass:: viser.TransformControlsEvent()

--- a/src/viser/__init__.py
+++ b/src/viser/__init__.py
@@ -55,6 +55,7 @@ from ._scene_handles import ScenePointerEvent as ScenePointerEvent
 from ._scene_handles import SplineCatmullRomHandle as SplineCatmullRomHandle
 from ._scene_handles import SplineCubicBezierHandle as SplineCubicBezierHandle
 from ._scene_handles import SpotLightHandle as SpotLightHandle
+from ._scene_handles import TransformControlsEvent as TransformControlsEvent
 from ._scene_handles import TransformControlsHandle as TransformControlsHandle
 from ._viser import CameraHandle as CameraHandle
 from ._viser import ClientHandle as ClientHandle

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -904,6 +904,20 @@ class TransformControlsUpdateMessage(Message):
 
 
 @dataclasses.dataclass
+class TransformControlsDragStartMessage(Message):
+    """Client -> server message when a transform control drag starts."""
+
+    name: str
+
+
+@dataclasses.dataclass
+class TransformControlsDragEndMessage(Message):
+    """Client -> server message when a transform control drag ends."""
+
+    name: str
+
+
+@dataclasses.dataclass
 class BackgroundImageMessage(Message):
     """Message for rendering a background image."""
 

--- a/src/viser/client/src/ControlPanel/ControlPanel.tsx
+++ b/src/viser/client/src/ControlPanel/ControlPanel.tsx
@@ -64,10 +64,10 @@ export default function ControlPanel(props: {
     controlWidthString == "small"
       ? "16em"
       : controlWidthString == "medium"
-        ? "20em"
-        : controlWidthString == "large"
-          ? "24em"
-          : null
+      ? "20em"
+      : controlWidthString == "large"
+      ? "24em"
+      : null
   )!;
 
   const generatedServerToggleButton = (

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1068,6 +1068,22 @@ export interface TransformControlsUpdateMessage {
   wxyz: [number, number, number, number];
   position: [number, number, number];
 }
+/** Client -> server message when a transform control drag starts.
+ *
+ * (automatically generated)
+ */
+export interface TransformControlsDragStartMessage {
+  type: "TransformControlsDragStartMessage";
+  name: string;
+}
+/** Client -> server message when a transform control drag ends.
+ *
+ * (automatically generated)
+ */
+export interface TransformControlsDragEndMessage {
+  type: "TransformControlsDragEndMessage";
+  name: string;
+}
 /** Message for rendering a background image.
  *
  * (automatically generated)
@@ -1368,6 +1384,8 @@ export type Message =
   | SetOrientationMessage
   | SetPositionMessage
   | TransformControlsUpdateMessage
+  | TransformControlsDragStartMessage
+  | TransformControlsDragEndMessage
   | BackgroundImageMessage
   | SetSceneNodeVisibilityMessage
   | SetSceneNodeClickableMessage

--- a/src/viser/client/src/components/MultiSliderComponent.tsx
+++ b/src/viser/client/src/components/MultiSliderComponent.tsx
@@ -168,7 +168,9 @@ export function MultiSlider({
   return (
     <Box
       id={id}
-      className={`multi-slider ${className || ""} ${disabled ? "disabled" : ""}`}
+      className={`multi-slider ${className || ""} ${
+        disabled ? "disabled" : ""
+      }`}
       pt={pt}
       pb={pb}
     >
@@ -191,7 +193,9 @@ export function MultiSlider({
             withinPortal
           >
             <div
-              className={`multi-slider-thumb ${activeThumb === index ? "active" : ""}`}
+              className={`multi-slider-thumb ${
+                activeThumb === index ? "active" : ""
+              }`}
               style={{
                 left: `${getPercentage(val)}%`,
                 backgroundColor: disabled

--- a/src/viser/client/src/components/colorUtils.ts
+++ b/src/viser/client/src/components/colorUtils.ts
@@ -30,12 +30,16 @@ export function toMantineColor(
 
 // Convert RGB tuple to rgb() string.
 export function rgbToString(rgb: RgbTuple): string {
-  return `rgb(${Math.round(rgb[0])}, ${Math.round(rgb[1])}, ${Math.round(rgb[2])})`;
+  return `rgb(${Math.round(rgb[0])}, ${Math.round(rgb[1])}, ${Math.round(
+    rgb[2],
+  )})`;
 }
 
 // Convert RGBA tuple to rgba() string.
 export function rgbaToString(rgba: RgbaTuple): string {
-  return `rgba(${Math.round(rgba[0])}, ${Math.round(rgba[1])}, ${Math.round(rgba[2])}, ${rgba[3].toFixed(2)})`;
+  return `rgba(${Math.round(rgba[0])}, ${Math.round(rgba[1])}, ${Math.round(
+    rgba[2],
+  )}, ${rgba[3].toFixed(2)})`;
 }
 
 // Parse any string to RGB tuple.


### PR DESCRIPTION
- Made callbacks for transform controls consistent with other callbacks. First argument is now an event, not the node itself.
    - This is a breaking change, but it's minor. I didn't find any existing repositories that this would affect.
- Added `on_drag_start` and `on_drag_end`. Addresses #476.
- Removed `on_click`, which wasn't working. It seems to have been included by accident.