### PR TITLE
Fix edit panel capitalization edge case

### DIFF
--- a/src/viser/client/src/ControlPanel/SceneTreeTable.tsx
+++ b/src/viser/client/src/ControlPanel/SceneTreeTable.tsx
@@ -118,7 +118,10 @@ function EditNodeProps({
           <Box style={{ fontWeight: "500", flexGrow: "1" }} fz="sm">
             {node.message.type
               .replace("Message", "")
-              .replace(/([A-Z])/g, " $1")
+              // First, handle patterns like "Gui3D" -> "Gui 3D" (lowercase + digit + uppercase)
+              .replace(/([a-z])(\d[A-Z])/g, "$1 $2")
+              // Then handle remaining camelCase patterns like "DContainer" -> "D Container"
+              .replace(/([a-z])([A-Z])/g, "$1 $2")
               .trim()}{" "}
             Props
           </Box>


### PR DESCRIPTION
Before:
- `Gui3D => Gui3 D`

Now:
- `Gui3D => Gui 3D`