### PR TITLE
Support both visual and collision meshes when loading URDF

### DIFF
--- a/examples/09_urdf_visualizer.py
+++ b/examples/09_urdf_visualizer.py
@@ -73,9 +73,15 @@ def main(
     # Load URDF.
     #
     # This takes either a yourdfpy.URDF object or a path to a .urdf file.
+    # NOTE: Properly supporting collision meshes requires
+    # https://github.com/robot-descriptions/robot_descriptions.py/pull/156
+    # to go in first and be released.
     viser_urdf = ViserUrdf(
         server,
         urdf_or_path=load_robot_description(robot_type + "_description"),
+        show_visuals=True,
+        show_collisions=False,
+        collision_mesh_color_override=(1.0, 0.0, 0.0),
     )
 
     # Create sliders in GUI that help us move the robot joints.

--- a/examples/09_urdf_visualizer.py
+++ b/examples/09_urdf_visualizer.py
@@ -66,8 +66,6 @@ def main(
         "anymal_c",
         "go2",
     ] = "panda",
-    show_visuals: bool = True,
-    show_collisions: bool = False,
 ) -> None:
     # Start viser server.
     server = viser.ViserServer()
@@ -75,19 +73,9 @@ def main(
     # Load URDF.
     #
     # This takes either a yourdfpy.URDF object or a path to a .urdf file.
-    # NOTE: Properly supporting collision meshes requires
-    # https://github.com/robot-descriptions/robot_descriptions.py/pull/156
-    # to go in first and be released.
     viser_urdf = ViserUrdf(
         server,
-        urdf_or_path=load_robot_description(
-            robot_type + "_description",
-            load_collision_meshes=show_collisions,
-            build_collision_scene_graph=show_collisions,
-        ),
-        show_visuals=show_visuals,
-        show_collisions=show_collisions,
-        collision_mesh_color_override=(1.0, 0.0, 0.0),
+        urdf_or_path=load_robot_description(robot_type + "_description"),
     )
 
     # Create sliders in GUI that help us move the robot joints.

--- a/examples/09_urdf_visualizer.py
+++ b/examples/09_urdf_visualizer.py
@@ -66,6 +66,8 @@ def main(
         "anymal_c",
         "go2",
     ] = "panda",
+    show_visuals: bool = True,
+    show_collisions: bool = False,
 ) -> None:
     # Start viser server.
     server = viser.ViserServer()
@@ -78,9 +80,13 @@ def main(
     # to go in first and be released.
     viser_urdf = ViserUrdf(
         server,
-        urdf_or_path=load_robot_description(robot_type + "_description"),
-        show_visuals=True,
-        show_collisions=False,
+        urdf_or_path=load_robot_description(
+            robot_type + "_description",
+            load_collision_meshes=show_collisions,
+            build_collision_scene_graph=show_collisions,
+        ),
+        show_visuals=show_visuals,
+        show_collisions=show_collisions,
         collision_mesh_color_override=(1.0, 0.0, 0.0),
     )
 

--- a/examples_dev/09_urdf_visualizer.py
+++ b/examples_dev/09_urdf_visualizer.py
@@ -75,15 +75,16 @@ def main(
     # Load URDF.
     #
     # This takes either a yourdfpy.URDF object or a path to a .urdf file.
+    urdf = load_robot_description(
+        robot_type + "_description",
+        load_meshes=load_meshes,
+        build_scene_graph=load_meshes,
+        load_collision_meshes=load_collision_meshes,
+        build_collision_scene_graph=load_collision_meshes,
+    )
     viser_urdf = ViserUrdf(
         server,
-        urdf_or_path=load_robot_description(
-            robot_type + "_description",
-            load_meshes=load_meshes,
-            build_scene_graph=load_meshes,
-            load_collision_meshes=load_collision_meshes,
-            build_collision_scene_graph=load_collision_meshes,
-        ),
+        urdf_or_path=urdf,
         load_meshes=load_meshes,
         load_collision_meshes=load_collision_meshes,
         collision_mesh_color_override=(1.0, 0.0, 0.0, 0.5),

--- a/examples_dev/09_urdf_visualizer.py
+++ b/examples_dev/09_urdf_visualizer.py
@@ -66,8 +66,8 @@ def main(
         "anymal_c",
         "go2",
     ] = "panda",
-    show_visuals: bool = True,
-    show_collisions: bool = False,
+    load_meshes: bool = True,
+    load_collision_meshes: bool = False,
 ) -> None:
     # Start viser server.
     server = viser.ViserServer()
@@ -79,14 +79,14 @@ def main(
         server,
         urdf_or_path=load_robot_description(
             robot_type + "_description",
-            load_meshes=show_visuals,
-            build_scene_graph=show_visuals,
-            load_collision_meshes=show_collisions,
-            build_collision_scene_graph=show_collisions,
+            load_meshes=load_meshes,
+            build_scene_graph=load_meshes,
+            load_collision_meshes=load_collision_meshes,
+            build_collision_scene_graph=load_collision_meshes,
         ),
-        show_visuals=show_visuals,
-        show_collisions=show_collisions,
-        collision_mesh_color_override=(1.0, 0.0, 0.0),
+        load_meshes=load_meshes,
+        load_collision_meshes=load_collision_meshes,
+        collision_mesh_color_override=(1.0, 0.0, 0.0, 0.5),
     )
 
     # Create sliders in GUI that help us move the robot joints.
@@ -94,6 +94,28 @@ def main(
         (slider_handles, initial_config) = create_robot_control_sliders(
             server, viser_urdf
         )
+
+    # Add visibility checkboxes.
+    with server.gui.add_folder("Visibility"):
+        show_meshes_cb = server.gui.add_checkbox(
+            "Show meshes",
+            viser_urdf.show_visual,
+        )
+        show_collision_meshes_cb = server.gui.add_checkbox(
+            "Show collision meshes", viser_urdf.show_collision
+        )
+
+    @show_meshes_cb.on_update
+    def _(_):
+        viser_urdf.show_visual = show_meshes_cb.value
+
+    @show_collision_meshes_cb.on_update
+    def _(_):
+        viser_urdf.show_collision = show_collision_meshes_cb.value
+
+    # Hide checkboxes if meshes are not loaded.
+    show_meshes_cb.visible = load_meshes
+    show_collision_meshes_cb.visible = load_collision_meshes
 
     # Set initial robot configuration.
     viser_urdf.update_cfg(np.array(initial_config))

--- a/examples_dev/09_urdf_visualizer.py
+++ b/examples_dev/09_urdf_visualizer.py
@@ -75,9 +75,6 @@ def main(
     # Load URDF.
     #
     # This takes either a yourdfpy.URDF object or a path to a .urdf file.
-    # NOTE: Properly supporting collision meshes requires
-    # https://github.com/robot-descriptions/robot_descriptions.py/pull/156
-    # to go in first and be released.
     viser_urdf = ViserUrdf(
         server,
         urdf_or_path=load_robot_description(

--- a/examples_dev/09_urdf_visualizer.py
+++ b/examples_dev/09_urdf_visualizer.py
@@ -66,6 +66,8 @@ def main(
         "anymal_c",
         "go2",
     ] = "panda",
+    show_visuals: bool = True,
+    show_collisions: bool = False,
 ) -> None:
     # Start viser server.
     server = viser.ViserServer()
@@ -73,9 +75,19 @@ def main(
     # Load URDF.
     #
     # This takes either a yourdfpy.URDF object or a path to a .urdf file.
+    # NOTE: Properly supporting collision meshes requires
+    # https://github.com/robot-descriptions/robot_descriptions.py/pull/156
+    # to go in first and be released.
     viser_urdf = ViserUrdf(
         server,
-        urdf_or_path=load_robot_description(robot_type + "_description"),
+        urdf_or_path=load_robot_description(
+            robot_type + "_description",
+            load_collision_meshes=show_collisions,
+            build_collision_scene_graph=show_collisions,
+        ),
+        show_visuals=show_visuals,
+        show_collisions=show_collisions,
+        collision_mesh_color_override=(1.0, 0.0, 0.0),
     )
 
     # Create sliders in GUI that help us move the robot joints.

--- a/examples_dev/09_urdf_visualizer.py
+++ b/examples_dev/09_urdf_visualizer.py
@@ -34,7 +34,7 @@ def create_robot_control_sliders(
     ) in viser_urdf.get_actuated_joint_limits().items():
         lower = lower if lower is not None else -np.pi
         upper = upper if upper is not None else np.pi
-        initial_pos = 0.0 if lower < 0 and upper > 0 else (lower + upper) / 2.0
+        initial_pos = 0.0 if lower < -0.1 and upper > 0.1 else (lower + upper) / 2.0
         slider = server.gui.add_slider(
             label=joint_name,
             min=lower,
@@ -79,6 +79,8 @@ def main(
         server,
         urdf_or_path=load_robot_description(
             robot_type + "_description",
+            load_meshes=show_visuals,
+            build_scene_graph=show_visuals,
             load_collision_meshes=show_collisions,
             build_collision_scene_graph=show_collisions,
         ),
@@ -97,6 +99,7 @@ def main(
     viser_urdf.update_cfg(np.array(initial_config))
 
     # Create grid.
+    trimesh_scene = viser_urdf._urdf.scene or viser_urdf._urdf.collision_scene
     server.scene.add_grid(
         "/grid",
         width=2,
@@ -105,7 +108,7 @@ def main(
             0.0,
             0.0,
             # Get the minimum z value of the trimesh scene.
-            viser_urdf._urdf.scene.bounds[0, 2],
+            trimesh_scene.bounds[0, 2] if trimesh_scene is not None else 0.0,
         ),
     )
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ examples = [
     "torch>=1.13.1",
     "matplotlib>=3.7.1",
     "plotly>=5.21.0",
-    "robot_descriptions>=1.10.0",
+    "robot_descriptions>=1.18.0",
     "gdown>=4.6.6",
     "plyfile",
     "opencv-python",

--- a/src/viser/client/src/ControlPanel/Generated.tsx
+++ b/src/viser/client/src/ControlPanel/Generated.tsx
@@ -79,8 +79,12 @@ function GuiContainer({ containerUuid }: { containerUuid: string }) {
   );
   const out = (
     <Box pt="xs">
-      {guiUuidOrderPairArray.map((pair) => (
-        <GeneratedInput key={pair.uuid} guiUuid={pair.uuid} />
+      {guiUuidOrderPairArray.map((pair, index) => (
+        <GeneratedInput
+          key={pair.uuid}
+          guiUuid={pair.uuid}
+          nextGuiUuid={guiUuidOrderPairArray[index + 1]?.uuid ?? null}
+        />
       ))}
     </Box>
   );
@@ -88,7 +92,10 @@ function GuiContainer({ containerUuid }: { containerUuid: string }) {
 }
 
 /** A single generated GUI element. */
-function GeneratedInput(props: { guiUuid: string }) {
+function GeneratedInput(props: {
+  guiUuid: string;
+  nextGuiUuid: string | null;
+}) {
   const viewer = React.useContext(ViewerContext)!;
   const conf = viewer.useGui((state) => state.guiConfigFromUuid[props.guiUuid]);
   if (conf === undefined) {
@@ -97,7 +104,7 @@ function GeneratedInput(props: { guiUuid: string }) {
   }
   switch (conf.type) {
     case "GuiFolderMessage":
-      return <FolderComponent {...conf} />;
+      return <FolderComponent {...conf} nextGuiUuid={props.nextGuiUuid} />;
     case "GuiTabGroupMessage":
       return <TabGroupComponent {...conf} />;
     case "GuiMarkdownMessage":

--- a/src/viser/client/src/components/Folder.css.ts
+++ b/src/viser/client/src/components/Folder.css.ts
@@ -6,14 +6,8 @@ export const folderWrapper = style({
   position: "relative",
   marginLeft: vars.spacing.xs,
   marginRight: vars.spacing.xs,
-  // If there's a GUI element above, we need more margin.
   marginTop: vars.spacing.xs,
-  // If there's a GUI element below, we need more margin.
-  // Note: 0.5em is the vertical margin below general GUI elements.
-  marginBottom: "1.2em",
-  ":last-child": {
-    marginBottom: "0.5em",
-  },
+  marginBottom: vars.spacing.xs,
   paddingBottom: `calc(${vars.spacing.xs} - 0.5em)`,
 });
 

--- a/src/viser/client/src/components/Folder.tsx
+++ b/src/viser/client/src/components/Folder.tsx
@@ -10,7 +10,8 @@ import { folderLabel, folderToggleIcon, folderWrapper } from "./Folder.css";
 export default function FolderComponent({
   uuid,
   props: { label, visible, expand_by_default },
-}: GuiFolderMessage) {
+  nextGuiUuid,
+}: GuiFolderMessage & { nextGuiUuid: string | null }) {
   const viewer = React.useContext(ViewerContext)!;
   const [opened, { toggle }] = useDisclosure(expand_by_default);
   const guiIdSet = viewer.useGui(
@@ -18,11 +19,18 @@ export default function FolderComponent({
   );
   const guiContext = React.useContext(GuiComponentContext)!;
   const isEmpty = guiIdSet === undefined || Object.keys(guiIdSet).length === 0;
+  const nextGuiType = viewer.useGui((state) =>
+    nextGuiUuid == null ? null : state.guiConfigFromUuid[nextGuiUuid]?.type,
+  );
 
   const ToggleIcon = opened ? IconChevronUp : IconChevronDown;
   if (!visible) return null;
   return (
-    <Paper withBorder className={folderWrapper}>
+    <Paper
+      withBorder
+      className={folderWrapper}
+      mb={nextGuiType === "GuiFolderMessage" ? "md" : undefined}
+    >
       <Paper
         className={folderLabel}
         style={{

--- a/src/viser/extras/_urdf.py
+++ b/src/viser/extras/_urdf.py
@@ -6,8 +6,8 @@ from typing import List, Tuple
 
 import numpy as np
 import trimesh
-from trimesh.scene import Scene
 import yourdfpy
+from trimesh.scene import Scene
 
 import viser
 

--- a/src/viser/extras/_urdf.py
+++ b/src/viser/extras/_urdf.py
@@ -6,6 +6,7 @@ from typing import List, Tuple
 
 import numpy as np
 import trimesh
+from trimesh.scene import Scene
 import yourdfpy
 
 import viser
@@ -172,7 +173,7 @@ class ViserUrdf:
 
     def _add_joint_frames_and_meshes(
         self,
-        scene: trimesh.scene.scene.Scene,
+        scene: Scene,
         root_node_name: str,
         collision_geometry: bool = False,
         mesh_color_override: tuple[float, float, float] | None = None,
@@ -237,7 +238,7 @@ class ViserUrdf:
 
 
 def _viser_name_from_frame(
-    scene: trimesh.scene.scene.Scene,
+    scene: Scene,
     frame_name: str,
     root_node_name: str = "/",
 ) -> str:

--- a/src/viser/extras/_urdf.py
+++ b/src/viser/extras/_urdf.py
@@ -9,6 +9,7 @@ import numpy as np
 import trimesh
 import yourdfpy
 from trimesh.scene import Scene
+from typing_extensions import assert_never
 
 import viser
 
@@ -159,7 +160,7 @@ class ViserUrdf:
             self._visual_root_frame.visible = visible
         else:
             warnings.warn(
-                "Cannot set visual_meshes_visible, since no visual meshes were loaded."
+                "Cannot set `.show_visual`, since no visual meshes were loaded."
             )
 
     @property
@@ -177,7 +178,7 @@ class ViserUrdf:
             self._collision_root_frame.visible = visible
         else:
             warnings.warn(
-                "Cannot set collision_meshes_visible, since no collision meshes were loaded."
+                "Cannot set `.show_collision`, since no collision meshes were loaded."
             )
 
     def remove(self) -> None:
@@ -292,6 +293,8 @@ class ViserUrdf:
                         opacity=mesh_color_override[3],
                     )
                 )
+            else:
+                assert_never(mesh_color_override)
         return root_frame
 
 

--- a/src/viser/extras/_urdf.py
+++ b/src/viser/extras/_urdf.py
@@ -172,7 +172,7 @@ class ViserUrdf:
 
     def _add_joint_frames_and_meshes(
         self,
-        scene: trimesh.scene.Scene,
+        scene: trimesh.scene.scene.Scene,
         root_node_name: str,
         collision_geometry: bool = False,
         mesh_color_override: tuple[float, float, float] | None = None,
@@ -237,7 +237,7 @@ class ViserUrdf:
 
 
 def _viser_name_from_frame(
-    scene: trimesh.scene.Scene,
+    scene: trimesh.scene.scene.Scene,
     frame_name: str,
     root_node_name: str = "/",
 ) -> str:

--- a/src/viser/extras/_urdf.py
+++ b/src/viser/extras/_urdf.py
@@ -141,11 +141,7 @@ class ViserUrdf:
     def update_cfg(self, configuration: np.ndarray) -> None:
         """Update the joint angles of the visualized URDF."""
         self._urdf.update_cfg(configuration)
-        for joint, frame_handle in zip(
-            self._joint_map_values,
-            self._joint_frames,
-            strict=True,
-        ):
+        for joint, frame_handle in zip(self._joint_map_values, self._joint_frames):
             assert isinstance(joint, yourdfpy.Joint)
             T_parent_child = self._urdf.get_transform(joint.child, joint.parent)
             frame_handle.wxyz = tf.SO3.from_matrix(T_parent_child[:3, :3]).wxyz


### PR DESCRIPTION
This PR adds the option to show either or both visual and collision meshes in the `ViserUrdf` utility, as shown in the videos below.

https://github.com/user-attachments/assets/a5bec95e-2508-4929-a8f1-cf74941f8a78

https://github.com/user-attachments/assets/4b562897-4c6c-4e5f-a4bc-c1099b2e0cd4

Note, however, that this required https://github.com/robot-descriptions/robot_descriptions.py/pull/156 for `load_robot_description` to even have the option to load collision meshes.

We can find a workaround for now, which is to construct the `yourdfpy.URDF` ourselves with a custom function, else we're going to need to wait for a `robot_descriptions.py` release and also pin the minimum version to have this functionality.

Thoughts?

Closes #483 