### PR TITLE
Ignore Ruff PLC0415: Import should be at the top level of a file

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,7 @@ lint.ignore = [
     "PLR0915",  # Too many statements.
     "PLR0913",  # Too many arguments.
     "PLC0414",  # Import alias does not rename variable. (this is used for exporting names)
+    "PLC0415",  # Import should be at the top-level of a file.
     "PLC1901",  # Use falsey strings.
     "PLR5501",  # Use `elif` instead of `else if`.
     "PLR0911",  # Too many return statements.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,11 +88,11 @@ lint.select = [
     "PLE",  # Pylint errors.
     "PLR",  # Pylint refactor recommendations.
     "PLW",  # Pylint warnings.
-    "I", # Import sorting.
+    "I",  # Import sorting.
 ]
 lint.ignore = [
     "E731",  # Do not assign a lambda expression, use a def.
-    "E741", # Ambiguous variable name. (l, O, or I)
+    "E741",  # Ambiguous variable name. (l, O, or I)
     "E501",  # Line too long.
     "E721",  # Do not compare types, use `isinstance()`.
     "F722",  # Forward annotation false positive from jaxtyping. Should be caught by pyright.
@@ -106,7 +106,7 @@ lint.ignore = [
     "PLR5501",  # Use `elif` instead of `else if`.
     "PLR0911",  # Too many return statements.
     "PLR0912",  # Too many branches.
-    "PLW0603",  # Globa statement updates are discouraged.
+    "PLW0603",  # Global statement updates are discouraged.
     "PLW2901",  # For loop variable overwritten.
     "PLW0642",  # Reassigned self in instance method.
 ]


### PR DESCRIPTION
This check was going off on unrelated code in my other PR, so this should make CI happy on `main`.

Digging in, it seems that PLC0415 is one of the checks that was taken off preview in the Ruff 0.12.0 release on June 17, 2025: https://github.com/astral-sh/ruff/releases/tag/0.12.0

Alternatively, we could go through and add specific `#noqa` comments to the dozens of offending lines... up to the maintainers!