### PR TITLE
Fix pose updates for re-added scene nodes

### DIFF
--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -765,16 +765,12 @@ export function SceneNodeThreeObject(props: { name: string }) {
     return true;
   }
 
-  // Pose needs to be updated whenever component is remounted.
+  // Pose needs to be updated whenever component is remounted / object is re-created.
   React.useEffect(() => {
-    const currentAttrs =
-      viewer.useSceneTree.getState().nodeAttributesFromName[props.name];
-    if (currentAttrs !== undefined) {
-      updateNodeAttributes(props.name, {
-        poseUpdateState: "needsUpdate",
-      });
-    }
-  }, []);
+    updateNodeAttributes(props.name, {
+      poseUpdateState: "needsUpdate",
+    });
+  }, [objNode]);
 
   // Update attributes on a per-frame basis. Currently does redundant work,
   // although this shouldn't be a bottleneck.


### PR DESCRIPTION
Fixes regression where pose updates fail when scene nodes are added twice.

To reproduce:
```python
import math
import time

import viser

server = viser.ViserServer()

mesh = server.scene.add_icosphere("/sphere", radius=0.5, color=(255, 0, 0))
print("make sphere")
time.sleep(1.0)

mesh = server.scene.add_icosphere("/sphere", radius=0.5, color=(255, 0, 0))
print("make sphere")
time.sleep(1.0)

while True:
    mesh.position = (math.sin(time.time() * 6.0), 0.0, 0.0)
    time.sleep(1.0 / 30.0)
```