### PR TITLE
Ensure transform control pose is updated after remounting

### DIFF
--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -792,6 +792,9 @@ export function SceneNodeThreeObject(props: { name: string }) {
         const displayed = isDisplayed();
         if (displayed && unmount) {
           if (objRef.current !== null) objRef.current.visible = false;
+          updateNodeAttributes(props.name, {
+            poseUpdateState: "needsUpdate",
+          });
           setUnmount(false);
         }
         if (!displayed && !unmount) {


### PR DESCRIPTION
  Fix control point position updates when visibility is toggled off

- Ensures control point positions are properly updated when scene nodes are made but initialized invisible.
- Added poseUpdateState: "needsUpdate" call (SceneTree.tsx:795) when a scene node is invisible.
- This ensures transform controls and other position-dependent elements stay synchronized.