### PR TITLE
More consistent API for splines: support numpy setters, rename `positions` => `points`

### DIFF
--- a/examples/18_lines.py
+++ b/examples/18_lines.py
@@ -35,7 +35,7 @@ def main() -> None:
         points = np.random.normal(size=(30, 3)) * 3.0
         server.scene.add_spline_catmull_rom(
             f"/catmull/{i}",
-            points=points,
+            positions=points,
             tension=0.5,
             line_width=3.0,
             color=np.random.uniform(size=3),
@@ -45,7 +45,7 @@ def main() -> None:
         control_points = np.random.normal(size=(30 * 2 - 2, 3)) * 3.0
         server.scene.add_spline_cubic_bezier(
             f"/cubic_bezier/{i}",
-            points=points,
+            positions=points,
             control_points=control_points,
             line_width=3.0,
             color=np.random.uniform(size=3),

--- a/examples/18_lines.py
+++ b/examples/18_lines.py
@@ -35,7 +35,7 @@ def main() -> None:
         points = np.random.normal(size=(30, 3)) * 3.0
         server.scene.add_spline_catmull_rom(
             f"/catmull/{i}",
-            positions=points,
+            points=points,
             tension=0.5,
             line_width=3.0,
             color=np.random.uniform(size=3),
@@ -45,7 +45,7 @@ def main() -> None:
         control_points = np.random.normal(size=(30 * 2 - 2, 3)) * 3.0
         server.scene.add_spline_cubic_bezier(
             f"/cubic_bezier/{i}",
-            positions=points,
+            points=points,
             control_points=control_points,
             line_width=3.0,
             color=np.random.uniform(size=3),

--- a/examples/20_scene_pointer.py
+++ b/examples/20_scene_pointer.py
@@ -95,11 +95,11 @@ def _(client: viser.ClientHandle) -> None:
         paint_button_handle.disabled = True
 
         @client.scene.on_pointer_event(event_type="rect-select")
-        def _(message: viser.ScenePointerEvent) -> None:
+        def _(event: viser.ScenePointerEvent) -> None:
             client.scene.remove_pointer_callback()
 
             global mesh_handle
-            camera = message.client.camera
+            camera = event.client.camera
 
             # Put the mesh in the camera frame.
             R_world_mesh = tf.SO3(mesh_handle.wxyz)
@@ -126,8 +126,8 @@ def _(client: viser.ClientHandle) -> None:
 
             # Select the vertices that lie inside the 2D selected box, once projected.
             mask = (
-                (vertices_proj > np.array(message.screen_pos[0]))
-                & (vertices_proj < np.array(message.screen_pos[1]))
+                (vertices_proj > np.array(event.screen_pos[0]))
+                & (vertices_proj < np.array(event.screen_pos[1]))
             ).all(axis=1)[..., None]
 
             # Update the mesh color based on whether the vertices are inside the box

--- a/examples_dev/18_lines.py
+++ b/examples_dev/18_lines.py
@@ -35,7 +35,7 @@ def main() -> None:
         points = np.random.normal(size=(30, 3)) * 3.0
         server.scene.add_spline_catmull_rom(
             f"/catmull/{i}",
-            positions=points,
+            points=points,
             tension=0.5,
             line_width=3.0,
             color=np.random.uniform(size=3),
@@ -45,7 +45,7 @@ def main() -> None:
         control_points = np.random.normal(size=(30 * 2 - 2, 3)) * 3.0
         server.scene.add_spline_cubic_bezier(
             f"/cubic_bezier/{i}",
-            positions=points,
+            points=points,
             control_points=control_points,
             line_width=3.0,
             color=np.random.uniform(size=3),

--- a/examples_dev/20_scene_pointer.py
+++ b/examples_dev/20_scene_pointer.py
@@ -95,11 +95,11 @@ def _(client: viser.ClientHandle) -> None:
         paint_button_handle.disabled = True
 
         @client.scene.on_pointer_event(event_type="rect-select")
-        def _(message: viser.ScenePointerEvent) -> None:
+        def _(event: viser.ScenePointerEvent) -> None:
             client.scene.remove_pointer_callback()
 
             global mesh_handle
-            camera = message.client.camera
+            camera = event.client.camera
 
             # Put the mesh in the camera frame.
             R_world_mesh = tf.SO3(mesh_handle.wxyz)
@@ -126,8 +126,8 @@ def _(client: viser.ClientHandle) -> None:
 
             # Select the vertices that lie inside the 2D selected box, once projected.
             mask = (
-                (vertices_proj > np.array(message.screen_pos[0]))
-                & (vertices_proj < np.array(message.screen_pos[1]))
+                (vertices_proj > np.array(event.screen_pos[0]))
+                & (vertices_proj < np.array(event.screen_pos[1]))
             ).all(axis=1)[..., None]
 
             # Update the mesh color based on whether the vertices are inside the box

--- a/src/viser/_assignable_props_api.py
+++ b/src/viser/_assignable_props_api.py
@@ -36,15 +36,15 @@ class AssignablePropsBase(Generic[TImpl]):
     def _cast_value_recursive(self, hint: Any, value: Any, prop_name: str) -> Any:
         """Recursively cast values to match type hints, handling arrays and tuples."""
         # Handle numpy arrays
+        if hint == npt.NDArray[np.float16]:
+            return np.asarray(value).astype(np.float16)
+        elif hint == npt.NDArray[np.float32]:
+            return np.asarray(value).astype(np.float32)
+        elif hint == npt.NDArray[np.float64]:
+            return np.asarray(value).astype(np.float64)
+        elif hint == npt.NDArray[np.uint8] and "color" in prop_name:
+            return colors_to_uint8(value)
         if isinstance(value, np.ndarray):
-            if hint == npt.NDArray[np.float32]:
-                return value.astype(np.float32)
-            elif hint == npt.NDArray[np.float16]:
-                return value.astype(np.float16)
-            elif hint == npt.NDArray[np.float64]:
-                return value.astype(np.float64)
-            elif hint == npt.NDArray[np.uint8] and "color" in prop_name:
-                return colors_to_uint8(value)
             return value
 
         # Handle tuple[T, ...] pattern

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1481,9 +1481,9 @@ class CatmullRomSplineMessage(_CreateSceneNodeMessage):
 
 @dataclasses.dataclass
 class CatmullRomSplineProps:
-    # TODO: consider renaming positions to points and using numpy arrays for consistency with LineSegmentsProps.
-    _points: Tuple[Tuple[float, float, float], ...]
-    """A tuple of 3D positions (x, y, z) defining the spline's path. Synchronized automatically when assigned."""
+    points: npt.NDArray[np.float32]
+    """Array with shape (N, 3) defining the spline's path. Synchronized
+    automatically when assigned."""
     curve_type: Literal["centripetal", "chordal", "catmullrom"]
     """Type of the curve ('centripetal', 'chordal', 'catmullrom'). Synchronized automatically when assigned."""
     tension: float
@@ -1507,10 +1507,11 @@ class CubicBezierSplineMessage(_CreateSceneNodeMessage):
 
 @dataclasses.dataclass
 class CubicBezierSplineProps:
-    _points: Tuple[Tuple[float, float, float], ...]
-    """A tuple of 3D positions (x, y, z) defining the spline's key points. Synchronized automatically when assigned."""
-    _control_points: Tuple[Tuple[float, float, float], ...]
-    """A tuple of control points for Bezier curve shaping. Synchronized automatically when assigned."""
+    points: npt.NDArray[np.float32]
+    """Array of shape (N, 3) defining the spline's key points. Synchronized
+    automatically when assigned."""
+    control_points: npt.NDArray[np.float32]
+    """Array of shape (2*N-2, 3) defining control points for Bezier curve shaping. Synchronized automatically when assigned."""
     line_width: float
     """Width of the spline line. Synchronized automatically when assigned."""
     color: Tuple[int, int, int]

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1482,7 +1482,7 @@ class CatmullRomSplineMessage(_CreateSceneNodeMessage):
 @dataclasses.dataclass
 class CatmullRomSplineProps:
     # TODO: consider renaming positions to points and using numpy arrays for consistency with LineSegmentsProps.
-    _positions: Tuple[Tuple[float, float, float], ...]
+    _points: Tuple[Tuple[float, float, float], ...]
     """A tuple of 3D positions (x, y, z) defining the spline's path. Synchronized automatically when assigned."""
     curve_type: Literal["centripetal", "chordal", "catmullrom"]
     """Type of the curve ('centripetal', 'chordal', 'catmullrom'). Synchronized automatically when assigned."""
@@ -1507,7 +1507,7 @@ class CubicBezierSplineMessage(_CreateSceneNodeMessage):
 
 @dataclasses.dataclass
 class CubicBezierSplineProps:
-    _positions: Tuple[Tuple[float, float, float], ...]
+    _points: Tuple[Tuple[float, float, float], ...]
     """A tuple of 3D positions (x, y, z) defining the spline's key points. Synchronized automatically when assigned."""
     _control_points: Tuple[Tuple[float, float, float], ...]
     """A tuple of control points for Bezier curve shaping. Synchronized automatically when assigned."""

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -1482,7 +1482,7 @@ class CatmullRomSplineMessage(_CreateSceneNodeMessage):
 @dataclasses.dataclass
 class CatmullRomSplineProps:
     # TODO: consider renaming positions to points and using numpy arrays for consistency with LineSegmentsProps.
-    positions: Tuple[Tuple[float, float, float], ...]
+    _positions: Tuple[Tuple[float, float, float], ...]
     """A tuple of 3D positions (x, y, z) defining the spline's path. Synchronized automatically when assigned."""
     curve_type: Literal["centripetal", "chordal", "catmullrom"]
     """Type of the curve ('centripetal', 'chordal', 'catmullrom'). Synchronized automatically when assigned."""
@@ -1507,9 +1507,9 @@ class CubicBezierSplineMessage(_CreateSceneNodeMessage):
 
 @dataclasses.dataclass
 class CubicBezierSplineProps:
-    positions: Tuple[Tuple[float, float, float], ...]
+    _positions: Tuple[Tuple[float, float, float], ...]
     """A tuple of 3D positions (x, y, z) defining the spline's key points. Synchronized automatically when assigned."""
-    control_points: Tuple[Tuple[float, float, float], ...]
+    _control_points: Tuple[Tuple[float, float, float], ...]
     """A tuple of control points for Bezier curve shaping. Synchronized automatically when assigned."""
     line_width: float
     """Width of the spline line. Synchronized automatically when assigned."""

--- a/src/viser/_scene_api.py
+++ b/src/viser/_scene_api.py
@@ -630,7 +630,7 @@ class SceneApi:
         self,
         name: str,
         points: np.ndarray,
-        colors: np.ndarray | tuple[float, float, float],
+        colors: np.ndarray | RgbTupleOrArray,
         line_width: float = 1,
         wxyz: tuple[float, float, float, float] | np.ndarray = (1.0, 0.0, 0.0, 0.0),
         position: tuple[float, float, float] | np.ndarray = (0.0, 0.0, 0.0),
@@ -643,8 +643,9 @@ class SceneApi:
                 be used to define a kinematic tree.
             points: A numpy array of shape (N, 2, 3) defining start/end points
                 for each of N line segments.
-            colors: Colors of points. Should have shape (N, 2, 3) or be
-                broadcastable to it.
+            colors: Colors of the line segments. Can be a single color as an RGB tuple or
+                np.ndarray of shape (3,) to apply to all segments, or an np.ndarray of
+                shape (N, 2, 3) to specify colors for each point of each segment.
             line_width: Width of the lines.
             wxyz: Quaternion rotation to parent frame from local frame (R_pl).
             position: Translation to parent frame from local frame (t_pl).
@@ -674,11 +675,17 @@ class SceneApi:
         )
         return LineSegmentsHandle._make(self, message, name, wxyz, position, visible)
 
-    def add_spline_catmull_rom(
+    # Important: this method is redeclared in a `if TYPE_CHECKING:` block below.
+    # The 'official' API is the redeclared version, which has stricter type hints.
+    #
+    # The implementation version here is looser for backwards compatibility reasons.
+    # It will be changed in the future to match the redeclared version.
+    #
+    def add_spline_catmull_rom(  # pyright: ignore[reportRedeclaration]
         self,
         name: str,
-        # The naming inconsistency here compared to add_line_segments is unfortunate...
-        positions: tuple[tuple[float, float, float], ...] | np.ndarray,
+        # `points` is actually required, we are keeping it optional at runtime for backwards-compatibility purposes.
+        points: tuple[tuple[float, float, float], ...] | np.ndarray = (),
         curve_type: Literal["centripetal", "chordal", "catmullrom"] = "centripetal",
         tension: float = 0.5,
         closed: bool = False,
@@ -688,10 +695,11 @@ class SceneApi:
         wxyz: tuple[float, float, float, float] | np.ndarray = (1.0, 0.0, 0.0, 0.0),
         position: tuple[float, float, float] | np.ndarray = (0.0, 0.0, 0.0),
         visible: bool = True,
+        **_deprecated_kwargs,
     ) -> SplineCatmullRomHandle:
         """Add a spline to the scene using Catmull-Rom interpolation.
 
-        This method creates a spline based on a set of positions and interpolates
+        This method creates a spline based on a set of points and interpolates
         them using the Catmull-Rom algorithm. This can be used to create smooth curves.
 
         .. note::
@@ -702,7 +710,7 @@ class SceneApi:
         Args:
             name: A scene tree name. Names in the format of /parent/child can be used to
                 define a kinematic tree.
-            positions: A tuple of 3D positions (x, y, z) defining the spline's path.
+            points: A tuple of 3D points (x, y, z) defining the spline's path.
             curve_type: Type of the curve ('centripetal', 'chordal', 'catmullrom').
             tension: Tension of the curve. Affects the tightness of the curve.
             closed: Boolean indicating if the spline is closed (forms a loop).
@@ -716,20 +724,43 @@ class SceneApi:
         Returns:
             Handle for manipulating scene node.
         """
-        if isinstance(positions, np.ndarray):
-            assert len(positions.shape) == 2 and positions.shape[1] == 3
-            positions = tuple(map(tuple, positions))  # type: ignore
-        assert len(positions[0]) == 3
-        assert isinstance(positions, tuple)
+        # Handle backward compatibility: support old 'positions' parameter
+        if "positions" in _deprecated_kwargs:
+            if points != ():
+                raise ValueError(
+                    "Cannot specify both 'points' and 'positions' parameters"
+                )
+            points = _deprecated_kwargs.pop("positions")
+            warnings.warn(
+                "The 'positions' parameter has been deprecated and renamed. Use 'points' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if _deprecated_kwargs:
+            raise TypeError(
+                f"Unexpected keyword arguments: {list(_deprecated_kwargs.keys())}"
+            )
+        if points == ():
+            raise ValueError(
+                "The 'points' parameter must be provided for a Catmull-Rom spline."
+            )
+
+        if isinstance(points, np.ndarray):
+            assert len(points.shape) == 2 and points.shape[1] == 3
+            points = tuple(map(tuple, points))  # type: ignore
+        elif isinstance(points, list):
+            points = tuple(tuple(p) if isinstance(p, list) else p for p in points)
+        assert len(points[0]) == 3
+        assert isinstance(points, tuple)
         message = _messages.CatmullRomSplineMessage(
             name,
             _messages.CatmullRomSplineProps(
-                positions,
-                curve_type,
-                tension,
-                closed,
-                line_width,
-                _encode_rgb(color),
+                _points=points,
+                curve_type=curve_type,
+                tension=tension,
+                closed=closed,
+                line_width=line_width,
+                color=_encode_rgb(color),
                 segments=segments,
             ),
         )
@@ -737,22 +768,48 @@ class SceneApi:
             self, message, name, wxyz, position, visible
         )
 
-    def add_spline_cubic_bezier(
+    if TYPE_CHECKING:
+
+        def add_spline_catmull_rom(
+            self,
+            name: str,
+            points: tuple[tuple[float, float, float], ...] | np.ndarray,
+            curve_type: Literal["centripetal", "chordal", "catmullrom"] = "centripetal",
+            tension: float = 0.5,
+            closed: bool = False,
+            line_width: float = 1,
+            color: RgbTupleOrArray = (20, 20, 20),
+            segments: int | None = None,
+            wxyz: tuple[float, float, float, float] | np.ndarray = (1.0, 0.0, 0.0, 0.0),
+            position: tuple[float, float, float] | np.ndarray = (0.0, 0.0, 0.0),
+            visible: bool = True,
+        ) -> SplineCatmullRomHandle: ...
+
+    # Important: this method is redeclared in a `if TYPE_CHECKING:` block below.
+    # The 'official' API is the redeclared version, which has stricter type hints.
+    #
+    # The implementation version here is looser for backwards compatibility reasons.
+    # It will be changed in the future to match the redeclared version.
+    #
+    def add_spline_cubic_bezier(  # pyright: ignore[reportRedeclaration]
         self,
         name: str,
-        positions: tuple[tuple[float, float, float], ...] | np.ndarray,
-        control_points: tuple[tuple[float, float, float], ...] | np.ndarray,
+        # `points` and `control_points` are actually required, we are keeping
+        # them optional at runtime for backwards-compatibility purposes.
+        points: tuple[tuple[float, float, float], ...] | np.ndarray = (),
+        control_points: tuple[tuple[float, float, float], ...] | np.ndarray = (),
         line_width: float = 1.0,
         color: RgbTupleOrArray = (20, 20, 20),
         segments: int | None = None,
         wxyz: tuple[float, float, float, float] | np.ndarray = (1.0, 0.0, 0.0, 0.0),
         position: tuple[float, float, float] | np.ndarray = (0.0, 0.0, 0.0),
         visible: bool = True,
+        **_deprecated_kwargs,
     ) -> SplineCubicBezierHandle:
         """Add a spline to the scene using Cubic Bezier interpolation.
 
         This method allows for the creation of a cubic Bezier spline based on given
-        positions and control points. It is useful for creating complex, smooth,
+        points and control points. It is useful for creating complex, smooth,
         curving shapes.
 
         .. note::
@@ -763,8 +820,11 @@ class SceneApi:
         Args:
             name: A scene tree name. Names in the format of /parent/child can be used to
                 define a kinematic tree.
-            positions: A tuple of 3D positions (x, y, z) defining the spline's key points.
-            control_points: A tuple of control points for Bezier curve shaping.
+            points: A tuple of 3D points (x, y, z) defining the spline's key points.
+            control_points: A tuple of control points for Bezier curve shaping. Must have
+                exactly `2 * len(points) - 2` control points. For a cubic Bezier with N
+                points, the curve passes through points[0], points[1], ..., points[N-1],
+                with two control points between each consecutive pair of points.
             line_width: Width of the spline line.
             color: Color of the spline as an RGB tuple.
             segments: Number of segments to divide the spline into.
@@ -775,30 +835,71 @@ class SceneApi:
         Returns:
             Handle for manipulating scene node.
         """
+        # Handle backward compatibility: support old 'positions' parameter
+        if "positions" in _deprecated_kwargs:
+            if points != ():
+                raise ValueError(
+                    "Cannot specify both 'points' and 'positions' parameters"
+                )
+            points = _deprecated_kwargs.pop("positions")
+            warnings.warn(
+                "The 'positions' parameter has been deprecated and renamed. Use 'points' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if _deprecated_kwargs:
+            raise TypeError(
+                f"Unexpected keyword arguments: {list(_deprecated_kwargs.keys())}"
+            )
+        if points == () or control_points == ():
+            raise ValueError(
+                "Both 'points' and 'control_points' must be provided for a cubic Bezier spline."
+            )
 
-        if isinstance(positions, np.ndarray):
-            assert len(positions.shape) == 2 and positions.shape[1] == 3
-            positions = tuple(map(tuple, positions))  # type: ignore
+        if isinstance(points, np.ndarray):
+            assert len(points.shape) == 2 and points.shape[1] == 3
+            points = tuple(map(tuple, points))  # type: ignore
+        elif isinstance(points, list):
+            points = tuple(tuple(p) if isinstance(p, list) else p for p in points)
         if isinstance(control_points, np.ndarray):
             assert len(control_points.shape) == 2 and control_points.shape[1] == 3
             control_points = tuple(map(tuple, control_points))  # type: ignore
+        elif isinstance(control_points, list):
+            control_points = tuple(
+                tuple(p) if isinstance(p, list) else p for p in control_points
+            )  # type: ignore
 
-        assert isinstance(positions, tuple)
+        assert isinstance(points, tuple)
         assert isinstance(control_points, tuple)
-        assert len(control_points) == (2 * len(positions) - 2)
+        assert len(control_points) == (2 * len(points) - 2)
         message = _messages.CubicBezierSplineMessage(
             name,
             _messages.CubicBezierSplineProps(
-                positions,
-                control_points,
-                line_width,
-                _encode_rgb(color),
+                _points=points,
+                _control_points=control_points,
+                line_width=line_width,
+                color=_encode_rgb(color),
                 segments=segments,
             ),
         )
         return SplineCubicBezierHandle._make(
             self, message, name, wxyz, position, visible
         )
+
+    if TYPE_CHECKING:
+
+        def add_spline_cubic_bezier(
+            self,
+            name: str,
+            points: tuple[tuple[float, float, float], ...] | np.ndarray,
+            control_points: tuple[tuple[float, float, float], ...] | np.ndarray,
+            line_width: float = 1.0,
+            color: RgbTupleOrArray = (20, 20, 20),
+            segments: int | None = None,
+            wxyz: tuple[float, float, float, float] | np.ndarray = (1.0, 0.0, 0.0, 0.0),
+            position: tuple[float, float, float] | np.ndarray = (0.0, 0.0, 0.0),
+            visible: bool = True,
+        ) -> SplineCubicBezierHandle: ...
 
     def add_camera_frustum(
         self,
@@ -816,7 +917,6 @@ class SceneApi:
         visible: bool = True,
         cast_shadow: bool = True,
         receive_shadow: bool = True,
-        *_removed_kwargs,
     ) -> CameraFrustumHandle:
         """Add a camera frustum to the scene for visualization.
 
@@ -847,13 +947,6 @@ class SceneApi:
         Returns:
             Handle for manipulating scene node.
         """
-
-        if "line_thickness" in _removed_kwargs:
-            warnings.warn(
-                "The 'line_thickness' argument has been removed. Please use 'line_width' instead. Note that the units have been changed from world space to screen space.",
-                DeprecationWarning,
-            )
-
         if image is not None:
             media_type, binary = _encode_image_binary(
                 image, format, jpeg_quality=jpeg_quality
@@ -1090,7 +1183,7 @@ class SceneApi:
         self,
         name: str,
         points: np.ndarray,
-        colors: np.ndarray | tuple[float, float, float],
+        colors: np.ndarray | RgbTupleOrArray,
         point_size: float = 0.1,
         point_shape: Literal[
             "square", "diamond", "circle", "rounded", "sparkle"
@@ -1105,7 +1198,9 @@ class SceneApi:
         Args:
             name: Name of scene node. Determines location in kinematic tree.
             points: Location of points. Should have shape (N, 3).
-            colors: Colors of points. Should have shape (N, 3) or (3,).
+            colors: Colors of the points. Can be a single color as an RGB tuple or
+                np.ndarray of shape (3,) to apply to all points, or an np.ndarray of
+                shape (N, 3) to specify colors for each point.
             point_size: Size of each point.
             point_shape: Shape to draw each point.
             precision: Precision of the point cloud data. The input points array

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -575,12 +575,48 @@ class SplineCatmullRomHandle(
 ):
     """Handle for Catmull-Rom splines."""
 
+    @property
+    def positions(self) -> tuple[tuple[float, float, float], ...]:
+        return self._positions
+
+    @positions.setter
+    def positions(
+        self, positions: tuple[tuple[float, float, float], ...] | np.ndarray
+    ) -> None:
+        from ._scene_api import cast_vector
+
+        self._positions = tuple(cast_vector(p, 3) for p in positions)
+
 
 class SplineCubicBezierHandle(
     SceneNodeHandle,
     _messages.CubicBezierSplineProps,
 ):
     """Handle for cubic Bezier splines."""
+
+    @property
+    def positions(self) -> tuple[tuple[float, float, float], ...]:
+        return self._positions
+
+    @positions.setter
+    def positions(
+        self, positions: tuple[tuple[float, float, float], ...] | np.ndarray
+    ) -> None:
+        from ._scene_api import cast_vector
+
+        self._positions = tuple(cast_vector(p, 3) for p in positions)
+
+    @property
+    def control_points(self) -> tuple[tuple[float, float, float], ...]:
+        return self._control_points
+
+    @control_points.setter
+    def control_points(
+        self, control_points: tuple[tuple[float, float, float], ...] | np.ndarray
+    ) -> None:
+        from ._scene_api import cast_vector
+
+        self._control_points = tuple(cast_vector(p, 3) for p in control_points)
 
 
 class GlbHandle(

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -576,16 +576,32 @@ class SplineCatmullRomHandle(
     """Handle for Catmull-Rom splines."""
 
     @property
+    def points(self) -> tuple[tuple[float, float, float], ...]:
+        """Get the spline points. This is the preferred property name."""
+        return self._points
+
+    @points.setter
+    def points(
+        self, points: tuple[tuple[float, float, float], ...] | np.ndarray
+    ) -> None:
+        """Set the spline points. This is the preferred property name."""
+        from ._scene_api import cast_vector
+
+        self._points = tuple(cast_vector(p, 3) for p in points)
+
+    @property
     def positions(self) -> tuple[tuple[float, float, float], ...]:
-        return self._positions
+        """Get the spline positions. Deprecated: use 'points' instead."""
+        return self._points
 
     @positions.setter
     def positions(
         self, positions: tuple[tuple[float, float, float], ...] | np.ndarray
     ) -> None:
+        """Set the spline positions. Deprecated: use 'points' instead."""
         from ._scene_api import cast_vector
 
-        self._positions = tuple(cast_vector(p, 3) for p in positions)
+        self._points = tuple(cast_vector(p, 3) for p in positions)
 
 
 class SplineCubicBezierHandle(
@@ -595,16 +611,32 @@ class SplineCubicBezierHandle(
     """Handle for cubic Bezier splines."""
 
     @property
+    def points(self) -> tuple[tuple[float, float, float], ...]:
+        """Get the spline points. This is the preferred property name."""
+        return self._points
+
+    @points.setter
+    def points(
+        self, points: tuple[tuple[float, float, float], ...] | np.ndarray
+    ) -> None:
+        """Set the spline points. This is the preferred property name."""
+        from ._scene_api import cast_vector
+
+        self._points = tuple(cast_vector(p, 3) for p in points)
+
+    @property
     def positions(self) -> tuple[tuple[float, float, float], ...]:
-        return self._positions
+        """Get the spline positions. Deprecated: use 'points' instead."""
+        return self._points
 
     @positions.setter
     def positions(
         self, positions: tuple[tuple[float, float, float], ...] | np.ndarray
     ) -> None:
+        """Set the spline positions. Deprecated: use 'points' instead."""
         from ._scene_api import cast_vector
 
-        self._positions = tuple(cast_vector(p, 3) for p in positions)
+        self._points = tuple(cast_vector(p, 3) for p in positions)
 
     @property
     def control_points(self) -> tuple[tuple[float, float, float], ...]:

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -19,7 +19,7 @@ from typing import (
 
 import numpy as np
 import numpy.typing as npt
-from typing_extensions import Self, override
+from typing_extensions import Self, deprecated, override
 
 from . import _messages
 from ._assignable_props_api import AssignablePropsBase
@@ -52,8 +52,13 @@ class ScenePointerEvent:
     For a box selection, this includes the min- and max- corners of the box."""
 
     @property
+    @deprecated("The `event` property is deprecated. Use `event_type` instead.")
     def event(self):
-        """Deprecated. Use `event_type` instead."""
+        """Deprecated. Use `event_type` instead.
+
+        .. deprecated::
+            The `event` property is deprecated. Use `event_type` instead.
+        """
         return self.event_type
 
 
@@ -590,17 +595,29 @@ class SplineCatmullRomHandle(
         self._points = tuple(cast_vector(p, 3) for p in points)
 
     @property
+    @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
     def positions(self) -> tuple[tuple[float, float, float], ...]:
-        """Get the spline positions. Deprecated: use 'points' instead."""
+        """Get the spline positions. Deprecated: use 'points' instead.
+
+        .. deprecated::
+            The 'positions' property is deprecated. Use 'points' instead.
+        """
         return self._points
 
     @positions.setter
+    @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
     def positions(
         self, positions: tuple[tuple[float, float, float], ...] | np.ndarray
     ) -> None:
-        """Set the spline positions. Deprecated: use 'points' instead."""
+        import warnings
+
         from ._scene_api import cast_vector
 
+        warnings.warn(
+            "The 'positions' property is deprecated. Use 'points' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._points = tuple(cast_vector(p, 3) for p in positions)
 
 
@@ -625,17 +642,29 @@ class SplineCubicBezierHandle(
         self._points = tuple(cast_vector(p, 3) for p in points)
 
     @property
+    @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
     def positions(self) -> tuple[tuple[float, float, float], ...]:
-        """Get the spline positions. Deprecated: use 'points' instead."""
+        """Get the spline positions. Deprecated: use 'points' instead.
+
+        .. deprecated::
+            The 'positions' property is deprecated. Use 'points' instead.
+        """
         return self._points
 
     @positions.setter
+    @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
     def positions(
         self, positions: tuple[tuple[float, float, float], ...] | np.ndarray
     ) -> None:
-        """Set the spline positions. Deprecated: use 'points' instead."""
+        import warnings
+
         from ._scene_api import cast_vector
 
+        warnings.warn(
+            "The 'positions' property is deprecated. Use 'points' instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         self._points = tuple(cast_vector(p, 3) for p in positions)
 
     @property

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -581,44 +581,33 @@ class SplineCatmullRomHandle(
     """Handle for Catmull-Rom splines."""
 
     @property
-    def points(self) -> tuple[tuple[float, float, float], ...]:
-        """Get the spline points. This is the preferred property name."""
-        return self._points
-
-    @points.setter
-    def points(
-        self, points: tuple[tuple[float, float, float], ...] | np.ndarray
-    ) -> None:
-        """Set the spline points. This is the preferred property name."""
-        from ._scene_api import cast_vector
-
-        self._points = tuple(cast_vector(p, 3) for p in points)
-
-    @property
     @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
     def positions(self) -> tuple[tuple[float, float, float], ...]:
         """Get the spline positions. Deprecated: use 'points' instead.
 
         .. deprecated::
-            The 'positions' property is deprecated. Use 'points' instead.
+            "The 'positions' tuple property is deprecated. Use the 'points' numpy array instead.",
         """
-        return self._points
-
-    @positions.setter
-    @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
-    def positions(
-        self, positions: tuple[tuple[float, float, float], ...] | np.ndarray
-    ) -> None:
         import warnings
 
-        from ._scene_api import cast_vector
-
         warnings.warn(
-            "The 'positions' property is deprecated. Use 'points' instead.",
+            "The 'positions' tuple property is deprecated. Use the 'points' numpy array instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        self._points = tuple(cast_vector(p, 3) for p in positions)
+        return tuple(tuple(x) for x in self.points.tolist())  # type: ignore
+
+    @positions.setter
+    @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
+    def positions(self, positions: tuple[tuple[float, float, float], ...]) -> None:
+        import warnings
+
+        warnings.warn(
+            "The 'positions' tuple property is deprecated. Use the 'points' numpy array instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.points = np.asarray(positions)
 
 
 class SplineCubicBezierHandle(
@@ -628,56 +617,30 @@ class SplineCubicBezierHandle(
     """Handle for cubic Bezier splines."""
 
     @property
-    def points(self) -> tuple[tuple[float, float, float], ...]:
-        """Get the spline points. This is the preferred property name."""
-        return self._points
-
-    @points.setter
-    def points(
-        self, points: tuple[tuple[float, float, float], ...] | np.ndarray
-    ) -> None:
-        """Set the spline points. This is the preferred property name."""
-        from ._scene_api import cast_vector
-
-        self._points = tuple(cast_vector(p, 3) for p in points)
-
-    @property
-    @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
+    @deprecated(
+        "The 'positions' tuple property is deprecated. Use 'points' numpy array instead."
+    )
     def positions(self) -> tuple[tuple[float, float, float], ...]:
         """Get the spline positions. Deprecated: use 'points' instead.
 
         .. deprecated::
-            The 'positions' property is deprecated. Use 'points' instead.
+            The 'positions' tuple property is deprecated. Use the 'points' numpy array instead.
         """
-        return self._points
+        return tuple(tuple(p) for p in self.points.tolist())  # type: ignore
 
     @positions.setter
-    @deprecated("The 'positions' property is deprecated. Use 'points' instead.")
-    def positions(
-        self, positions: tuple[tuple[float, float, float], ...] | np.ndarray
-    ) -> None:
+    @deprecated(
+        "The 'positions' tuple property is deprecated. Use the 'points' numpy array instead."
+    )
+    def positions(self, positions: tuple[tuple[float, float, float], ...]) -> None:
         import warnings
 
-        from ._scene_api import cast_vector
-
         warnings.warn(
-            "The 'positions' property is deprecated. Use 'points' instead.",
+            "The 'positions' tuple property is deprecated. Use the 'points' numpy array instead.",
             DeprecationWarning,
             stacklevel=2,
         )
-        self._points = tuple(cast_vector(p, 3) for p in positions)
-
-    @property
-    def control_points(self) -> tuple[tuple[float, float, float], ...]:
-        return self._control_points
-
-    @control_points.setter
-    def control_points(
-        self, control_points: tuple[tuple[float, float, float], ...] | np.ndarray
-    ) -> None:
-        from ._scene_api import cast_vector
-
-        self._control_points = tuple(cast_vector(p, 3) for p in control_points)
+        self.points = np.asarray(positions)
 
 
 class GlbHandle(

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -765,16 +765,12 @@ export function SceneNodeThreeObject(props: { name: string }) {
     return true;
   }
 
-  // Pose needs to be updated whenever component is remounted.
+  // Pose needs to be updated whenever component is remounted / object is re-created.
   React.useEffect(() => {
-    const currentAttrs =
-      viewer.useSceneTree.getState().nodeAttributesFromName[props.name];
-    if (currentAttrs !== undefined) {
-      updateNodeAttributes(props.name, {
-        poseUpdateState: "needsUpdate",
-      });
-    }
-  }, []);
+    updateNodeAttributes(props.name, {
+      poseUpdateState: "needsUpdate",
+    });
+  }, [objNode]);
 
   // Update attributes on a per-frame basis. Currently does redundant work,
   // although this shouldn't be a bottleneck.

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -510,7 +510,7 @@ function createObjectFactory(
           return (
             <group ref={ref}>
               <CatmullRomLine
-                points={message.props._positions}
+                points={message.props._points}
                 closed={message.props.closed}
                 curveType={message.props.curve_type}
                 tension={message.props.tension}
@@ -529,11 +529,11 @@ function createObjectFactory(
       return {
         makeObject: (ref, children) => (
           <group ref={ref}>
-            {[...Array(message.props._positions.length - 1).keys()].map((i) => (
+            {[...Array(message.props._points.length - 1).keys()].map((i) => (
               <CubicBezierLine
                 key={i}
-                start={message.props._positions[i]}
-                end={message.props._positions[i + 1]}
+                start={message.props._points[i]}
+                end={message.props._points[i + 1]}
                 midA={message.props._control_points[2 * i]}
                 midB={message.props._control_points[2 * i + 1]}
                 lineWidth={message.props.line_width}

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -510,7 +510,7 @@ function createObjectFactory(
           return (
             <group ref={ref}>
               <CatmullRomLine
-                points={message.props.positions}
+                points={message.props._positions}
                 closed={message.props.closed}
                 curveType={message.props.curve_type}
                 tension={message.props.tension}
@@ -529,13 +529,13 @@ function createObjectFactory(
       return {
         makeObject: (ref, children) => (
           <group ref={ref}>
-            {[...Array(message.props.positions.length - 1).keys()].map((i) => (
+            {[...Array(message.props._positions.length - 1).keys()].map((i) => (
               <CubicBezierLine
                 key={i}
-                start={message.props.positions[i]}
-                end={message.props.positions[i + 1]}
-                midA={message.props.control_points[2 * i]}
-                midB={message.props.control_points[2 * i + 1]}
+                start={message.props._positions[i]}
+                end={message.props._positions[i + 1]}
+                midA={message.props._control_points[2 * i]}
+                midB={message.props._control_points[2 * i + 1]}
                 lineWidth={message.props.line_width}
                 color={rgbToInt(message.props.color)}
                 // Sketchy cast needed due to https://github.com/pmndrs/drei/issues/1476.

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -85,21 +85,15 @@ function SceneNodeLabel(props: { name: string }) {
   ) : null;
 }
 
-function tripletListFromFloat32Buffer(buffer: Uint8Array) {
-  const array = new Float32Array(
-    buffer.buffer.slice(
-      buffer.byteOffset,
-      buffer.byteOffset + buffer.byteLength,
-    ),
-  );
-  if (array.length % 3 !== 0) {
-    throw new Error(
-      `CatmullRomSplineMessage: points buffer length must be a multiple of 3, got ${array.length}`,
-    );
-  }
+function tripletListFromFloat32Buffer(data: Uint8Array<ArrayBufferLike>) {
+  const arrayView = new DataView(data.buffer, data.byteOffset, data.byteLength);
   const triplets: [number, number, number][] = [];
-  for (let i = 0; i < array.length; i += 3) {
-    triplets.push([array[i], array[i + 1], array[i + 2]]);
+  for (let i = 0; i < arrayView.byteLength; i += 12) {
+    triplets.push([
+      arrayView.getFloat32(i, true), // little-endian
+      arrayView.getFloat32(i + 4, true),
+      arrayView.getFloat32(i + 8, true),
+    ]);
   }
   return triplets;
 }

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -390,7 +390,7 @@ export interface CatmullRomSplineMessage {
   type: "CatmullRomSplineMessage";
   name: string;
   props: {
-    _positions: [number, number, number][];
+    _points: [number, number, number][];
     curve_type: "centripetal" | "chordal" | "catmullrom";
     tension: number;
     closed: boolean;
@@ -407,7 +407,7 @@ export interface CubicBezierSplineMessage {
   type: "CubicBezierSplineMessage";
   name: string;
   props: {
-    _positions: [number, number, number][];
+    _points: [number, number, number][];
     _control_points: [number, number, number][];
     line_width: number;
     color: [number, number, number];

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -390,7 +390,7 @@ export interface CatmullRomSplineMessage {
   type: "CatmullRomSplineMessage";
   name: string;
   props: {
-    _points: [number, number, number][];
+    points: Uint8Array;
     curve_type: "centripetal" | "chordal" | "catmullrom";
     tension: number;
     closed: boolean;
@@ -407,8 +407,8 @@ export interface CubicBezierSplineMessage {
   type: "CubicBezierSplineMessage";
   name: string;
   props: {
-    _points: [number, number, number][];
-    _control_points: [number, number, number][];
+    points: Uint8Array;
+    control_points: Uint8Array;
     line_width: number;
     color: [number, number, number];
     segments: number | null;

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -390,7 +390,7 @@ export interface CatmullRomSplineMessage {
   type: "CatmullRomSplineMessage";
   name: string;
   props: {
-    positions: [number, number, number][];
+    _positions: [number, number, number][];
     curve_type: "centripetal" | "chordal" | "catmullrom";
     tension: number;
     closed: boolean;
@@ -407,8 +407,8 @@ export interface CubicBezierSplineMessage {
   type: "CubicBezierSplineMessage";
   name: string;
   props: {
-    positions: [number, number, number][];
-    control_points: [number, number, number][];
+    _positions: [number, number, number][];
+    _control_points: [number, number, number][];
     line_width: number;
     color: [number, number, number];
     segments: number | null;


### PR DESCRIPTION
Improved spline API consistency:

1. **API rename**: `positions` → `points` with deprecation warnings for backward compatibility

2. **Numpy arrays for geometry**: `points` and `control_points` now use numpy arrays instead of nested tuples, matching other viser APIs (also backwards compatible)