### PR TITLE
Fix RGBA regression for images, revisit media_type / format props

### DIFF
--- a/src/viser/_gui_api.py
+++ b/src/viser/_gui_api.py
@@ -702,7 +702,7 @@ class GuiApi:
             props=_messages.GuiImageProps(
                 _data=None,  # Sent in prop update later.
                 label=label,
-                media_type="image/png" if format == "png" else "image/jpeg",
+                format=format,
                 order=_apply_default_order(order),
                 visible=visible,
             ),

--- a/src/viser/_gui_handles.py
+++ b/src/viser/_gui_handles.py
@@ -714,9 +714,9 @@ def _get_data_url(url: str, image_root: Path | None) -> str:
         image_root = Path(__file__).parent
     try:
         image = iio.imread(image_root / url)
-        media_type, binary = _encode_image_binary(image, "png")
+        binary = _encode_image_binary(image, "png")
         url = base64.b64encode(binary).decode("utf-8")
-        return f"data:{media_type};base64,{url}"
+        return f"data:image/png;base64,{url}"
     except (IOError, FileNotFoundError):
         warnings.warn(
             f"Failed to read image {url}, with image_root set to {image_root}.",
@@ -814,8 +814,6 @@ class GuiImageHandle(_GuiHandle[None], GuiImageProps):
     @image.setter
     def image(self, image: np.ndarray) -> None:
         self._image = image
-        media_type, data = _encode_image_binary(
-            image, self.media_type, jpeg_quality=self._jpeg_quality
+        self._data = _encode_image_binary(
+            image, self.format, jpeg_quality=self._jpeg_quality
         )
-        self._data = data
-        del media_type

--- a/src/viser/_messages.py
+++ b/src/viser/_messages.py
@@ -238,8 +238,9 @@ class CameraFrustumProps:
     """Width of the frustum lines. Synchronized automatically when assigned."""
     color: Tuple[int, int, int]
     """Color of the frustum as RGB integers. Synchronized automatically when assigned."""
-    image_media_type: Optional[Literal["image/jpeg", "image/png"]]
-    """Format of the provided image ('image/jpeg' or 'image/png'). Synchronized automatically when assigned."""
+    format: Literal["jpeg", "png"]
+    """Format of the provided image ('jpeg' or 'png'). Synchronized
+    automatically when assigned."""
     _image_data: Optional[bytes]
     """Optional image to be displayed on the frustum. Synchronized automatically when assigned."""
     cast_shadow: bool
@@ -951,7 +952,7 @@ class TransformControlsDragEndMessage(Message):
 class BackgroundImageMessage(Message):
     """Message for rendering a background image."""
 
-    media_type: Literal["image/jpeg", "image/png"]
+    format: Literal["jpeg", "png"]
     rgb_data: Optional[bytes]
     depth_data: Optional[bytes]
 
@@ -965,8 +966,9 @@ class ImageMessage(_CreateSceneNodeMessage):
 
 @dataclasses.dataclass
 class ImageProps:
-    media_type: Literal["image/jpeg", "image/png"]
-    """Format of the provided image ('image/jpeg' or 'image/png'). Synchronized automatically when assigned."""
+    format: Literal["jpeg", "png"]
+    """Format of the provided image ('jpeg' or 'png'). Synchronized
+    automatically when assigned."""
     _data: bytes
     """Binary data of the image. Synchronized automatically when assigned."""
     render_width: float
@@ -1171,8 +1173,9 @@ class GuiImageProps:
     """Label text for the image. Synchronized automatically when assigned."""
     _data: Optional[bytes]
     """Binary data of the image. Synchronized automatically when assigned."""
-    media_type: Literal["image/jpeg", "image/png"]
-    """Format of the provided image ('image/jpeg' or 'image/png'). Synchronized automatically when assigned."""
+    format: Literal["jpeg", "png"]
+    """Format of the provided image ('jpeg' or 'png'). Synchronized
+    automatically when assigned."""
     visible: bool
     """Visibility state of the image. Synchronized automatically when assigned."""
 

--- a/src/viser/_scene_handles.py
+++ b/src/viser/_scene_handles.py
@@ -321,15 +321,9 @@ class CameraFrustumHandle(
             self._image_data = None
             return
 
-        if self.image_media_type is None:
-            self.image_media_type = "image/png"
-
         self._image = image
-        media_type, data = _encode_image_binary(
-            image, self.image_media_type, jpeg_quality=self._jpeg_quality
-        )
+        data = _encode_image_binary(image, self.format, jpeg_quality=self._jpeg_quality)
         self._image_data = data
-        del media_type
 
     def compute_canonical_frustum_size(self) -> tuple[float, float, float]:
         """Compute the X, Y, and Z dimensions of the frustum if it had
@@ -667,11 +661,8 @@ class ImageHandle(
         from ._scene_api import _encode_image_binary
 
         self._image = image
-        media_type, data = _encode_image_binary(
-            image, self.media_type, jpeg_quality=self._jpeg_quality
-        )
+        data = _encode_image_binary(image, self.format, jpeg_quality=self._jpeg_quality)
         self._data = data
-        del media_type
 
 
 class LabelHandle(

--- a/src/viser/client/src/CameraFrustumVariants.tsx
+++ b/src/viser/client/src/CameraFrustumVariants.tsx
@@ -16,12 +16,11 @@ export const CameraFrustumComponent = React.forwardRef<
   const [imageTexture, setImageTexture] = React.useState<THREE.Texture>();
 
   React.useEffect(() => {
-    if (
-      message.props.image_media_type !== null &&
-      message.props._image_data !== null
-    ) {
+    if (message.props.format !== null && message.props._image_data !== null) {
       const image_url = URL.createObjectURL(
-        new Blob([message.props._image_data]),
+        new Blob([message.props._image_data], {
+          type: "image/" + message.props.format,
+        }),
       );
       new THREE.TextureLoader().load(image_url, (texture) => {
         setImageTexture(texture);
@@ -30,7 +29,7 @@ export const CameraFrustumComponent = React.forwardRef<
     } else {
       setImageTexture(undefined);
     }
-  }, [message.props.image_media_type, message.props._image_data]);
+  }, [message.props.format, message.props._image_data]);
 
   let y = Math.tan(message.props.fov / 2.0);
   let x = y * message.props.aspect;

--- a/src/viser/client/src/MessageHandler.tsx
+++ b/src/viser/client/src/MessageHandler.tsx
@@ -374,7 +374,7 @@ function useMessageHandler(): (message: Message) => void {
         if (message.rgb_data !== null) {
           const rgb_url = URL.createObjectURL(
             new Blob([message.rgb_data], {
-              type: message.media_type,
+              type: "image/" + message.format,
             }),
           );
           new TextureLoader().load(rgb_url, (texture) => {
@@ -405,7 +405,7 @@ function useMessageHandler(): (message: Message) => void {
           // If depth is available set the texture
           const depth_url = URL.createObjectURL(
             new Blob([message.depth_data], {
-              type: message.media_type,
+              type: "image/" + message.format,
             }),
           );
           new TextureLoader().load(depth_url, (texture) => {

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -489,14 +489,16 @@ export const ViserImage = React.forwardRef<
   const [imageTexture, setImageTexture] = React.useState<THREE.Texture>();
 
   React.useEffect(() => {
-    if (message.props.media_type !== null && message.props._data !== null) {
-      const image_url = URL.createObjectURL(new Blob([message.props._data]));
+    if (message.props.format !== null && message.props._data !== null) {
+      const image_url = URL.createObjectURL(new Blob([message.props._data]), {
+        type: "image/" + message.props.format,
+      });
       new THREE.TextureLoader().load(image_url, (texture) => {
         setImageTexture(texture);
         URL.revokeObjectURL(image_url);
       });
     }
-  }, [message.props.media_type, message.props._data]);
+  }, [message.props.format, message.props._data]);
   return (
     <group ref={ref}>
       <mesh

--- a/src/viser/client/src/WebsocketMessages.ts
+++ b/src/viser/client/src/WebsocketMessages.ts
@@ -1,7 +1,7 @@
 // AUTOMATICALLY GENERATED message interfaces, from Python dataclass definitions.
 // This file should not be manually modified.
 /** Variant of CameraMessage used for visualizing camera frustums.
- *
+ * 
  * OpenCV convention, +Z forward.
  *
  * (automatically generated)
@@ -9,18 +9,7 @@
 export interface CameraFrustumMessage {
   type: "CameraFrustumMessage";
   name: string;
-  props: {
-    fov: number;
-    aspect: number;
-    scale: number;
-    line_width: number;
-    color: [number, number, number];
-    image_media_type: "image/jpeg" | "image/png" | null;
-    _image_data: Uint8Array | null;
-    cast_shadow: boolean;
-    receive_shadow: boolean;
-    variant: "wireframe" | "filled";
-  };
+  props: {'fov': number, 'aspect': number, 'scale': number, 'line_width': number, 'color': [number, number, number], 'format': 'jpeg' | 'png', '_image_data': (Uint8Array | null), 'cast_shadow': boolean, 'receive_shadow': boolean, 'variant': 'wireframe' | 'filled'};
 }
 /** GlTF message.
  *
@@ -29,12 +18,7 @@ export interface CameraFrustumMessage {
 export interface GlbMessage {
   type: "GlbMessage";
   name: string;
-  props: {
-    glb_data: Uint8Array;
-    scale: number;
-    cast_shadow: boolean;
-    receive_shadow: boolean;
-  };
+  props: {'glb_data': Uint8Array, 'scale': number, 'cast_shadow': boolean, 'receive_shadow': boolean};
 }
 /** Coordinate frame message.
  *
@@ -43,16 +27,10 @@ export interface GlbMessage {
 export interface FrameMessage {
   type: "FrameMessage";
   name: string;
-  props: {
-    show_axes: boolean;
-    axes_length: number;
-    axes_radius: number;
-    origin_radius: number;
-    origin_color: [number, number, number];
-  };
+  props: {'show_axes': boolean, 'axes_length': number, 'axes_radius': number, 'origin_radius': number, 'origin_color': [number, number, number]};
 }
 /** Batched axes message.
- *
+ * 
  * Positions and orientations should follow a `T_parent_local` convention, which
  * corresponds to the R matrix and t vector in `p_parent = [R | t] p_local`.
  *
@@ -61,13 +39,7 @@ export interface FrameMessage {
 export interface BatchedAxesMessage {
   type: "BatchedAxesMessage";
   name: string;
-  props: {
-    batched_wxyzs: Uint8Array;
-    batched_positions: Uint8Array;
-    batched_scales: Uint8Array | null;
-    axes_length: number;
-    axes_radius: number;
-  };
+  props: {'batched_wxyzs': Uint8Array, 'batched_positions': Uint8Array, 'batched_scales': (Uint8Array | null), 'axes_length': number, 'axes_radius': number};
 }
 /** Grid message. Helpful for visualizing things like ground planes.
  *
@@ -76,20 +48,7 @@ export interface BatchedAxesMessage {
 export interface GridMessage {
   type: "GridMessage";
   name: string;
-  props: {
-    width: number;
-    height: number;
-    width_segments: number;
-    height_segments: number;
-    plane: "xz" | "xy" | "yx" | "yz" | "zx" | "zy";
-    cell_color: [number, number, number];
-    cell_thickness: number;
-    cell_size: number;
-    section_color: [number, number, number];
-    section_thickness: number;
-    section_size: number;
-    shadow_opacity: number;
-  };
+  props: {'width': number, 'height': number, 'width_segments': number, 'height_segments': number, 'plane': 'xz' | 'xy' | 'yx' | 'yz' | 'zx' | 'zy', 'cell_color': [number, number, number], 'cell_thickness': number, 'cell_size': number, 'section_color': [number, number, number], 'section_thickness': number, 'section_size': number, 'shadow_opacity': number};
 }
 /** Add a 2D label to the scene.
  *
@@ -98,7 +57,7 @@ export interface GridMessage {
 export interface LabelMessage {
   type: "LabelMessage";
   name: string;
-  props: { text: string };
+  props: {'text': string};
 }
 /** Add a 3D gui element to the scene.
  *
@@ -107,12 +66,12 @@ export interface LabelMessage {
 export interface Gui3DMessage {
   type: "Gui3DMessage";
   name: string;
-  props: { order: number; container_uuid: string };
+  props: {'order': number, 'container_uuid': string};
 }
 /** Point cloud message.
- *
+ * 
  * Positions are internally canonicalized to float32, colors to uint8.
- *
+ * 
  * Float color inputs should be in the range [0,1], int color inputs should be in the
  * range [0,255].
  *
@@ -121,13 +80,7 @@ export interface Gui3DMessage {
 export interface PointCloudMessage {
   type: "PointCloudMessage";
   name: string;
-  props: {
-    points: Uint8Array;
-    colors: Uint8Array;
-    point_size: number;
-    point_shape: "square" | "diamond" | "circle" | "rounded" | "sparkle";
-    precision: "float16" | "float32";
-  };
+  props: {'points': (Uint8Array), 'colors': Uint8Array, 'point_size': number, 'point_shape': 'square' | 'diamond' | 'circle' | 'rounded' | 'sparkle', 'precision': 'float16' | 'float32'};
 }
 /** Directional light message.
  *
@@ -136,11 +89,7 @@ export interface PointCloudMessage {
 export interface DirectionalLightMessage {
   type: "DirectionalLightMessage";
   name: string;
-  props: {
-    color: [number, number, number];
-    intensity: number;
-    cast_shadow: boolean;
-  };
+  props: {'color': [number, number, number], 'intensity': number, 'cast_shadow': boolean};
 }
 /** Ambient light message.
  *
@@ -149,7 +98,7 @@ export interface DirectionalLightMessage {
 export interface AmbientLightMessage {
   type: "AmbientLightMessage";
   name: string;
-  props: { color: [number, number, number]; intensity: number };
+  props: {'color': [number, number, number], 'intensity': number};
 }
 /** Hemisphere light message.
  *
@@ -158,11 +107,7 @@ export interface AmbientLightMessage {
 export interface HemisphereLightMessage {
   type: "HemisphereLightMessage";
   name: string;
-  props: {
-    sky_color: [number, number, number];
-    ground_color: [number, number, number];
-    intensity: number;
-  };
+  props: {'sky_color': [number, number, number], 'ground_color': [number, number, number], 'intensity': number};
 }
 /** Point light message.
  *
@@ -171,13 +116,7 @@ export interface HemisphereLightMessage {
 export interface PointLightMessage {
   type: "PointLightMessage";
   name: string;
-  props: {
-    color: [number, number, number];
-    intensity: number;
-    distance: number;
-    decay: number;
-    cast_shadow: boolean;
-  };
+  props: {'color': [number, number, number], 'intensity': number, 'distance': number, 'decay': number, 'cast_shadow': boolean};
 }
 /** Rectangular Area light message.
  *
@@ -186,12 +125,7 @@ export interface PointLightMessage {
 export interface RectAreaLightMessage {
   type: "RectAreaLightMessage";
   name: string;
-  props: {
-    color: [number, number, number];
-    intensity: number;
-    width: number;
-    height: number;
-  };
+  props: {'color': [number, number, number], 'intensity': number, 'width': number, 'height': number};
 }
 /** Spot light message.
  *
@@ -200,18 +134,10 @@ export interface RectAreaLightMessage {
 export interface SpotLightMessage {
   type: "SpotLightMessage";
   name: string;
-  props: {
-    color: [number, number, number];
-    intensity: number;
-    distance: number;
-    angle: number;
-    penumbra: number;
-    decay: number;
-    cast_shadow: boolean;
-  };
+  props: {'color': [number, number, number], 'intensity': number, 'distance': number, 'angle': number, 'penumbra': number, 'decay': number, 'cast_shadow': boolean};
 }
 /** Mesh message.
- *
+ * 
  * Vertices are internally canonicalized to float32, faces to uint32.
  *
  * (automatically generated)
@@ -219,18 +145,7 @@ export interface SpotLightMessage {
 export interface MeshMessage {
   type: "MeshMessage";
   name: string;
-  props: {
-    vertices: Uint8Array;
-    faces: Uint8Array;
-    color: [number, number, number];
-    wireframe: boolean;
-    opacity: number | null;
-    flat_shading: boolean;
-    side: "front" | "back" | "double";
-    material: "standard" | "toon3" | "toon5";
-    cast_shadow: boolean;
-    receive_shadow: boolean;
-  };
+  props: {'vertices': Uint8Array, 'faces': Uint8Array, 'color': [number, number, number], 'wireframe': boolean, 'opacity': (number | null), 'flat_shading': boolean, 'side': 'front' | 'back' | 'double', 'material': 'standard' | 'toon3' | 'toon5', 'cast_shadow': boolean, 'receive_shadow': boolean};
 }
 /** Box message.
  *
@@ -239,17 +154,7 @@ export interface MeshMessage {
 export interface BoxMessage {
   type: "BoxMessage";
   name: string;
-  props: {
-    dimensions: [number, number, number];
-    color: [number, number, number];
-    wireframe: boolean;
-    opacity: number | null;
-    flat_shading: boolean;
-    side: "front" | "back" | "double";
-    material: "standard" | "toon3" | "toon5";
-    cast_shadow: boolean;
-    receive_shadow: boolean;
-  };
+  props: {'dimensions': [number, number, number], 'color': [number, number, number], 'wireframe': boolean, 'opacity': (number | null), 'flat_shading': boolean, 'side': 'front' | 'back' | 'double', 'material': 'standard' | 'toon3' | 'toon5', 'cast_shadow': boolean, 'receive_shadow': boolean};
 }
 /** Icosphere message.
  *
@@ -258,18 +163,7 @@ export interface BoxMessage {
 export interface IcosphereMessage {
   type: "IcosphereMessage";
   name: string;
-  props: {
-    radius: number;
-    subdivisions: number;
-    color: [number, number, number];
-    wireframe: boolean;
-    opacity: number | null;
-    flat_shading: boolean;
-    side: "front" | "back" | "double";
-    material: "standard" | "toon3" | "toon5";
-    cast_shadow: boolean;
-    receive_shadow: boolean;
-  };
+  props: {'radius': number, 'subdivisions': number, 'color': [number, number, number], 'wireframe': boolean, 'opacity': (number | null), 'flat_shading': boolean, 'side': 'front' | 'back' | 'double', 'material': 'standard' | 'toon3' | 'toon5', 'cast_shadow': boolean, 'receive_shadow': boolean};
 }
 /** Skinned mesh message.
  *
@@ -278,22 +172,7 @@ export interface IcosphereMessage {
 export interface SkinnedMeshMessage {
   type: "SkinnedMeshMessage";
   name: string;
-  props: {
-    vertices: Uint8Array;
-    faces: Uint8Array;
-    color: [number, number, number];
-    wireframe: boolean;
-    opacity: number | null;
-    flat_shading: boolean;
-    side: "front" | "back" | "double";
-    material: "standard" | "toon3" | "toon5";
-    cast_shadow: boolean;
-    receive_shadow: boolean;
-    bone_wxyzs: Uint8Array;
-    bone_positions: Uint8Array;
-    skin_indices: Uint8Array;
-    skin_weights: Uint8Array;
-  };
+  props: {'vertices': Uint8Array, 'faces': Uint8Array, 'color': [number, number, number], 'wireframe': boolean, 'opacity': (number | null), 'flat_shading': boolean, 'side': 'front' | 'back' | 'double', 'material': 'standard' | 'toon3' | 'toon5', 'cast_shadow': boolean, 'receive_shadow': boolean, 'bone_wxyzs': Uint8Array, 'bone_positions': Uint8Array, 'skin_indices': Uint8Array, 'skin_weights': Uint8Array};
 }
 /** Message from server->client carrying batched meshes information.
  *
@@ -302,22 +181,7 @@ export interface SkinnedMeshMessage {
 export interface BatchedMeshesMessage {
   type: "BatchedMeshesMessage";
   name: string;
-  props: {
-    batched_wxyzs: Uint8Array;
-    batched_positions: Uint8Array;
-    batched_scales: Uint8Array | null;
-    lod: "auto" | "off" | [number, number][];
-    vertices: Uint8Array;
-    faces: Uint8Array;
-    batched_colors: Uint8Array;
-    wireframe: boolean;
-    opacity: number | null;
-    flat_shading: boolean;
-    side: "front" | "back" | "double";
-    material: "standard" | "toon3" | "toon5";
-    cast_shadow: boolean;
-    receive_shadow: boolean;
-  };
+  props: {'batched_wxyzs': Uint8Array, 'batched_positions': Uint8Array, 'batched_scales': (Uint8Array | null), 'lod': ('auto' | 'off' | [number, number][]), 'vertices': Uint8Array, 'faces': Uint8Array, 'batched_colors': Uint8Array, 'wireframe': boolean, 'opacity': (number | null), 'flat_shading': boolean, 'side': 'front' | 'back' | 'double', 'material': 'standard' | 'toon3' | 'toon5', 'cast_shadow': boolean, 'receive_shadow': boolean};
 }
 /** Message from server->client carrying batched GLB information.
  *
@@ -326,15 +190,7 @@ export interface BatchedMeshesMessage {
 export interface BatchedGlbMessage {
   type: "BatchedGlbMessage";
   name: string;
-  props: {
-    batched_wxyzs: Uint8Array;
-    batched_positions: Uint8Array;
-    batched_scales: Uint8Array | null;
-    lod: "auto" | "off" | [number, number][];
-    glb_data: Uint8Array;
-    cast_shadow: boolean;
-    receive_shadow: boolean;
-  };
+  props: {'batched_wxyzs': Uint8Array, 'batched_positions': Uint8Array, 'batched_scales': (Uint8Array | null), 'lod': ('auto' | 'off' | [number, number][]), 'glb_data': Uint8Array, 'cast_shadow': boolean, 'receive_shadow': boolean};
 }
 /** Message for transform gizmos.
  *
@@ -343,19 +199,7 @@ export interface BatchedGlbMessage {
 export interface TransformControlsMessage {
   type: "TransformControlsMessage";
   name: string;
-  props: {
-    scale: number;
-    line_width: number;
-    fixed: boolean;
-    active_axes: [boolean, boolean, boolean];
-    disable_axes: boolean;
-    disable_sliders: boolean;
-    disable_rotations: boolean;
-    translation_limits: [[number, number], [number, number], [number, number]];
-    rotation_limits: [[number, number], [number, number], [number, number]];
-    depth_test: boolean;
-    opacity: number;
-  };
+  props: {'scale': number, 'line_width': number, 'fixed': boolean, 'active_axes': [boolean, boolean, boolean], 'disable_axes': boolean, 'disable_sliders': boolean, 'disable_rotations': boolean, 'translation_limits': [[number, number], [number, number], [number, number]], 'rotation_limits': [[number, number], [number, number], [number, number]], 'depth_test': boolean, 'opacity': number};
 }
 /** Message for rendering 2D images.
  *
@@ -364,14 +208,7 @@ export interface TransformControlsMessage {
 export interface ImageMessage {
   type: "ImageMessage";
   name: string;
-  props: {
-    media_type: "image/jpeg" | "image/png";
-    _data: Uint8Array;
-    render_width: number;
-    render_height: number;
-    cast_shadow: boolean;
-    receive_shadow: boolean;
-  };
+  props: {'format': 'jpeg' | 'png', '_data': Uint8Array, 'render_width': number, 'render_height': number, 'cast_shadow': boolean, 'receive_shadow': boolean};
 }
 /** Message from server->client carrying line segments information.
  *
@@ -380,7 +217,7 @@ export interface ImageMessage {
 export interface LineSegmentsMessage {
   type: "LineSegmentsMessage";
   name: string;
-  props: { points: Uint8Array; line_width: number; colors: Uint8Array };
+  props: {'points': Uint8Array, 'line_width': number, 'colors': Uint8Array};
 }
 /** Message from server->client carrying Catmull-Rom spline information.
  *
@@ -389,15 +226,7 @@ export interface LineSegmentsMessage {
 export interface CatmullRomSplineMessage {
   type: "CatmullRomSplineMessage";
   name: string;
-  props: {
-    points: Uint8Array;
-    curve_type: "centripetal" | "chordal" | "catmullrom";
-    tension: number;
-    closed: boolean;
-    line_width: number;
-    color: [number, number, number];
-    segments: number | null;
-  };
+  props: {'points': Uint8Array, 'curve_type': 'centripetal' | 'chordal' | 'catmullrom', 'tension': number, 'closed': boolean, 'line_width': number, 'color': [number, number, number], 'segments': (number | null)};
 }
 /** Message from server->client carrying Cubic Bezier spline information.
  *
@@ -406,13 +235,7 @@ export interface CatmullRomSplineMessage {
 export interface CubicBezierSplineMessage {
   type: "CubicBezierSplineMessage";
   name: string;
-  props: {
-    points: Uint8Array;
-    control_points: Uint8Array;
-    line_width: number;
-    color: [number, number, number];
-    segments: number | null;
-  };
+  props: {'points': Uint8Array, 'control_points': Uint8Array, 'line_width': number, 'color': [number, number, number], 'segments': (number | null)};
 }
 /** Message from server->client carrying splattable Gaussians.
  *
@@ -421,7 +244,7 @@ export interface CubicBezierSplineMessage {
 export interface GaussianSplatsMessage {
   type: "GaussianSplatsMessage";
   name: string;
-  props: { buffer: Uint8Array };
+  props: {'buffer': Uint8Array};
 }
 /** Remove a particular node from the scene.
  *
@@ -439,12 +262,7 @@ export interface GuiFolderMessage {
   type: "GuiFolderMessage";
   uuid: string;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    visible: boolean;
-    expand_by_default: boolean;
-  };
+  props: {'order': number, 'label': string, 'visible': boolean, 'expand_by_default': boolean};
 }
 /** GuiMarkdownMessage(uuid: 'str', container_uuid: 'str', props: 'GuiMarkdownProps')
  *
@@ -454,7 +272,7 @@ export interface GuiMarkdownMessage {
   type: "GuiMarkdownMessage";
   uuid: string;
   container_uuid: string;
-  props: { order: number; _markdown: string; visible: boolean };
+  props: {'order': number, '_markdown': string, 'visible': boolean};
 }
 /** GuiHtmlMessage(uuid: 'str', container_uuid: 'str', props: 'GuiHtmlProps')
  *
@@ -464,7 +282,7 @@ export interface GuiHtmlMessage {
   type: "GuiHtmlMessage";
   uuid: string;
   container_uuid: string;
-  props: { order: number; content: string; visible: boolean };
+  props: {'order': number, 'content': string, 'visible': boolean};
 }
 /** GuiProgressBarMessage(uuid: 'str', value: 'float', container_uuid: 'str', props: 'GuiProgressBarProps')
  *
@@ -475,28 +293,7 @@ export interface GuiProgressBarMessage {
   uuid: string;
   value: number;
   container_uuid: string;
-  props: {
-    order: number;
-    animated: boolean;
-    color:
-      | "dark"
-      | "gray"
-      | "red"
-      | "pink"
-      | "grape"
-      | "violet"
-      | "indigo"
-      | "blue"
-      | "cyan"
-      | "green"
-      | "lime"
-      | "yellow"
-      | "orange"
-      | "teal"
-      | [number, number, number]
-      | null;
-    visible: boolean;
-  };
+  props: {'order': number, 'animated': boolean, 'color': ('dark' | 'gray' | 'red' | 'pink' | 'grape' | 'violet' | 'indigo' | 'blue' | 'cyan' | 'green' | 'lime' | 'yellow' | 'orange' | 'teal' | [number, number, number] | null), 'visible': boolean};
 }
 /** GuiPlotlyMessage(uuid: 'str', container_uuid: 'str', props: 'GuiPlotlyProps')
  *
@@ -506,12 +303,7 @@ export interface GuiPlotlyMessage {
   type: "GuiPlotlyMessage";
   uuid: string;
   container_uuid: string;
-  props: {
-    order: number;
-    _plotly_json_str: string;
-    aspect: number;
-    visible: boolean;
-  };
+  props: {'order': number, '_plotly_json_str': string, 'aspect': number, 'visible': boolean};
 }
 /** GuiUplotMessage(uuid: 'str', container_uuid: 'str', props: 'GuiUplotProps')
  *
@@ -521,189 +313,7 @@ export interface GuiUplotMessage {
   type: "GuiUplotMessage";
   uuid: string;
   container_uuid: string;
-  props: {
-    order: number;
-    data: Uint8Array[];
-    mode: 1 | 2 | null;
-    title: string | null;
-    series: {
-      show?: boolean;
-      class?: string;
-      scale?: string;
-      auto?: boolean;
-      sorted?: 0 | 1 | -1;
-      spanGaps?: boolean;
-      gaps?: [number, number][] | never;
-      pxAlign?: number | boolean;
-      label?: string | never;
-      value?: string | never;
-      values?: never;
-      paths?: never;
-      points?: {
-        show?: boolean | never;
-        paths?: never;
-        filter?: number[] | null | never;
-        size?: number;
-        space?: number;
-        width?: number;
-        stroke?: string;
-        dash?: number[];
-        cap?: string;
-        fill?: string;
-      };
-      facets?: { scale: string; auto?: boolean; sorted?: 0 | 1 | -1 }[];
-      width?: number;
-      stroke?: string;
-      fill?: string;
-      fillTo?: number | never;
-      dash?: number[];
-      cap?: string;
-      alpha?: number;
-      idxs?: [number, number];
-      min?: number;
-      max?: number;
-    }[];
-    bands: { series: [number, number]; fill?: string; dir?: 1 | -1 }[] | null;
-    scales: {
-      [key: string]: {
-        time?: boolean;
-        auto?: boolean | never;
-        range?: [number | null, number | null] | never | any;
-        from?: string;
-        distr?: 1 | 2 | 3 | 4 | 100;
-        log?: 10 | 2;
-        clamp?: number | never;
-        asinh?: number;
-        fwd?: never;
-        bwd?: never;
-        min?: number;
-        max?: number;
-        dir?: 1 | -1;
-        ori?: 0 | 1;
-        key?: string;
-      };
-    } | null;
-    axes:
-      | {
-          show?: boolean;
-          scale?: string;
-          side?: 0 | 1 | 2 | 3;
-          size?: number | never;
-          gap?: number;
-          font?: string;
-          lineGap?: number;
-          stroke?: string;
-          label?: string | never;
-          labelSize?: number;
-          labelGap?: number;
-          labelFont?: string;
-          space?: number | never;
-          incrs?: number[] | never;
-          splits?: number[] | never;
-          filter?: never;
-          values?:
-            | (string | number | null)[]
-            | never
-            | string
-            | (string | number | null)[][];
-          rotate?: number | never;
-          align?: 1 | 2;
-          alignTo?: 1 | 2;
-          grid?: {
-            show?: boolean;
-            stroke?: string;
-            width?: number;
-            dash?: number[];
-            cap?: string;
-            filter?: never;
-          };
-          ticks?: {
-            show?: boolean;
-            stroke?: string;
-            width?: number;
-            dash?: number[];
-            cap?: string;
-            filter?: never;
-            size?: number;
-          };
-          border?: {
-            show?: boolean;
-            stroke?: string;
-            width?: number;
-            dash?: number[];
-            cap?: string;
-          };
-        }[]
-      | null;
-    legend: {
-      show?: boolean;
-      live?: boolean;
-      isolate?: boolean;
-      markers?: {
-        show?: boolean;
-        width?: number | never;
-        stroke?: string;
-        fill?: string;
-        dash?: string;
-      };
-      mount?: any;
-      idx?: number | null;
-      idxs?: (number | null)[];
-      values?: (string | never)[];
-    } | null;
-    cursor: {
-      show?: boolean;
-      x?: boolean;
-      y?: boolean;
-      left?: number;
-      top?: number;
-      idx?: number | null;
-      dataIdx?: never;
-      idxs?: (number | null)[];
-      move?: never;
-      points?: {
-        show?: boolean | never;
-        one?: boolean;
-        size?: number | never;
-        bbox?: never;
-        width?: number | never;
-        stroke?: string;
-        fill?: string;
-      };
-      bind?: {
-        mousedown?: never;
-        mouseup?: never;
-        click?: never;
-        dblclick?: never;
-        mousemove?: never;
-        mouseleave?: never;
-        mouseenter?: never;
-      };
-      drag?: {
-        setScale?: boolean;
-        x?: boolean;
-        y?: boolean;
-        dist?: number;
-        uni?: number;
-        click?: any;
-      };
-      sync?: {
-        key: string;
-        setSeries?: boolean;
-        scales?: [string | null, string | null];
-        match?: [never, never, any, any, never];
-        filters?: any;
-        values?: [number, number];
-      };
-      focus?: { prox: number; bias?: 0 | 1 | -1; dist?: any };
-      hover?: { prox?: number | null | any; bias?: 0 | 1 | -1; skip?: any[] };
-      lock?: boolean;
-      event?: never;
-    } | null;
-    focus: { alpha: number } | null;
-    aspect: number;
-    visible: boolean;
-  };
+  props: {'order': number, 'data': Uint8Array[], 'mode': (1 | 2 | null), 'title': (string | null), 'series': {'show'?: boolean, 'class'?: string, 'scale'?: string, 'auto'?: boolean, 'sorted'?: 0 | 1 | -1, 'spanGaps'?: boolean, 'gaps'?: ([number, number][] | never), 'pxAlign'?: (number | boolean), 'label'?: (string | never), 'value'?: (string | never), 'values'?: never, 'paths'?: never, 'points'?: {'show'?: (boolean | never), 'paths'?: never, 'filter'?: (number[] | null | never), 'size'?: number, 'space'?: number, 'width'?: number, 'stroke'?: string, 'dash'?: number[], 'cap'?: string, 'fill'?: string}, 'facets'?: {'scale': string, 'auto'?: boolean, 'sorted'?: 0 | 1 | -1}[], 'width'?: number, 'stroke'?: string, 'fill'?: string, 'fillTo'?: (number | never), 'dash'?: number[], 'cap'?: string, 'alpha'?: number, 'idxs'?: [number, number], 'min'?: number, 'max'?: number}[], 'bands': ({'series': [number, number], 'fill'?: string, 'dir'?: (1 | -1)}[] | null), 'scales': ({[key: string]: {'time'?: boolean, 'auto'?: (boolean | never), 'range'?: ([(number | null), (number | null)] | never | any), 'from'?: string, 'distr'?: 1 | 2 | 3 | 4 | 100, 'log'?: (10 | 2), 'clamp'?: (number | never), 'asinh'?: number, 'fwd'?: never, 'bwd'?: never, 'min'?: number, 'max'?: number, 'dir'?: (1 | -1), 'ori'?: (0 | 1), 'key'?: string}} | null), 'axes': ({'show'?: boolean, 'scale'?: string, 'side'?: 0 | 1 | 2 | 3, 'size'?: (number | never), 'gap'?: number, 'font'?: string, 'lineGap'?: number, 'stroke'?: string, 'label'?: (string | never), 'labelSize'?: number, 'labelGap'?: number, 'labelFont'?: string, 'space'?: (number | never), 'incrs'?: (number[] | never), 'splits'?: (number[] | never), 'filter'?: never, 'values'?: ((string | number | null)[] | never | string | (string | number | null)[][]), 'rotate'?: (number | never), 'align'?: 1 | 2, 'alignTo'?: 1 | 2, 'grid'?: {'show'?: boolean, 'stroke'?: string, 'width'?: number, 'dash'?: number[], 'cap'?: string, 'filter'?: never}, 'ticks'?: {'show'?: boolean, 'stroke'?: string, 'width'?: number, 'dash'?: number[], 'cap'?: string, 'filter'?: never, 'size'?: number}, 'border'?: {'show'?: boolean, 'stroke'?: string, 'width'?: number, 'dash'?: number[], 'cap'?: string}}[] | null), 'legend': ({'show'?: boolean, 'live'?: boolean, 'isolate'?: boolean, 'markers'?: {'show'?: boolean, 'width'?: (number | never), 'stroke'?: string, 'fill'?: string, 'dash'?: string}, 'mount'?: any, 'idx'?: (number | null), 'idxs'?: (number | null)[], 'values'?: (string | never)[]} | null), 'cursor': ({'show'?: boolean, 'x'?: boolean, 'y'?: boolean, 'left'?: number, 'top'?: number, 'idx'?: (number | null), 'dataIdx'?: never, 'idxs'?: (number | null)[], 'move'?: never, 'points'?: {'show'?: (boolean | never), 'one'?: boolean, 'size'?: (number | never), 'bbox'?: never, 'width'?: (number | never), 'stroke'?: string, 'fill'?: string}, 'bind'?: {'mousedown'?: never, 'mouseup'?: never, 'click'?: never, 'dblclick'?: never, 'mousemove'?: never, 'mouseleave'?: never, 'mouseenter'?: never}, 'drag'?: {'setScale'?: boolean, 'x'?: boolean, 'y'?: boolean, 'dist'?: number, 'uni'?: number, 'click'?: any}, 'sync'?: {'key': string, 'setSeries'?: boolean, 'scales'?: [(string | null), (string | null)], 'match'?: [never, never, any, any, never], 'filters'?: any, 'values'?: [number, number]}, 'focus'?: {'prox': number, 'bias'?: 0 | 1 | -1, 'dist'?: any}, 'hover'?: {'prox'?: (number | null | any), 'bias'?: 0 | 1 | -1, 'skip'?: any[]}, 'lock'?: boolean, 'event'?: never} | null), 'focus': ({'alpha': number} | null), 'aspect': number, 'visible': boolean};
 }
 /** GuiImageMessage(uuid: 'str', container_uuid: 'str', props: 'GuiImageProps')
  *
@@ -713,13 +323,7 @@ export interface GuiImageMessage {
   type: "GuiImageMessage";
   uuid: string;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string | null;
-    _data: Uint8Array | null;
-    media_type: "image/jpeg" | "image/png";
-    visible: boolean;
-  };
+  props: {'order': number, 'label': (string | null), '_data': (Uint8Array | null), 'format': 'jpeg' | 'png', 'visible': boolean};
 }
 /** GuiTabGroupMessage(uuid: 'str', container_uuid: 'str', props: 'GuiTabGroupProps')
  *
@@ -729,13 +333,7 @@ export interface GuiTabGroupMessage {
   type: "GuiTabGroupMessage";
   uuid: string;
   container_uuid: string;
-  props: {
-    _tab_labels: string[];
-    _tab_icons_html: (string | null)[];
-    _tab_container_ids: string[];
-    order: number;
-    visible: boolean;
-  };
+  props: {'_tab_labels': string[], '_tab_icons_html': (string | null)[], '_tab_container_ids': string[], 'order': number, 'visible': boolean};
 }
 /** GuiButtonMessage(uuid: 'str', value: 'bool', container_uuid: 'str', props: 'GuiButtonProps')
  *
@@ -746,31 +344,7 @@ export interface GuiButtonMessage {
   uuid: string;
   value: boolean;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    color:
-      | "dark"
-      | "gray"
-      | "red"
-      | "pink"
-      | "grape"
-      | "violet"
-      | "indigo"
-      | "blue"
-      | "cyan"
-      | "green"
-      | "lime"
-      | "yellow"
-      | "orange"
-      | "teal"
-      | [number, number, number]
-      | null;
-    _icon_html: string | null;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'color': ('dark' | 'gray' | 'red' | 'pink' | 'grape' | 'violet' | 'indigo' | 'blue' | 'cyan' | 'green' | 'lime' | 'yellow' | 'orange' | 'teal' | [number, number, number] | null), '_icon_html': (string | null)};
 }
 /** GuiUploadButtonMessage(uuid: 'str', container_uuid: 'str', props: 'GuiUploadButtonProps')
  *
@@ -780,32 +354,7 @@ export interface GuiUploadButtonMessage {
   type: "GuiUploadButtonMessage";
   uuid: string;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    color:
-      | "dark"
-      | "gray"
-      | "red"
-      | "pink"
-      | "grape"
-      | "violet"
-      | "indigo"
-      | "blue"
-      | "cyan"
-      | "green"
-      | "lime"
-      | "yellow"
-      | "orange"
-      | "teal"
-      | [number, number, number]
-      | null;
-    _icon_html: string | null;
-    mime_type: string;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'color': ('dark' | 'gray' | 'red' | 'pink' | 'grape' | 'violet' | 'indigo' | 'blue' | 'cyan' | 'green' | 'lime' | 'yellow' | 'orange' | 'teal' | [number, number, number] | null), '_icon_html': (string | null), 'mime_type': string};
 }
 /** GuiSliderMessage(uuid: 'str', value: 'float', container_uuid: 'str', props: 'GuiSliderProps')
  *
@@ -816,18 +365,7 @@ export interface GuiSliderMessage {
   uuid: string;
   value: number;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    min: number;
-    max: number;
-    step: number;
-    precision: number;
-    _marks: { value: number; label: string | null }[] | null;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'min': number, 'max': number, 'step': number, 'precision': number, '_marks': ({'value': number, 'label': (string | null)}[] | null)};
 }
 /** GuiMultiSliderMessage(uuid: 'str', value: 'Tuple[float, ...]', container_uuid: 'str', props: 'GuiMultiSliderProps')
  *
@@ -838,20 +376,7 @@ export interface GuiMultiSliderMessage {
   uuid: string;
   value: number[];
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    min: number;
-    max: number;
-    step: number;
-    min_range: number | null;
-    precision: number;
-    fixed_endpoints: boolean;
-    _marks: { value: number; label: string | null }[] | null;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'min': number, 'max': number, 'step': number, 'min_range': (number | null), 'precision': number, 'fixed_endpoints': boolean, '_marks': ({'value': number, 'label': (string | null)}[] | null)};
 }
 /** GuiNumberMessage(uuid: 'str', value: 'float', container_uuid: 'str', props: 'GuiNumberProps')
  *
@@ -862,17 +387,7 @@ export interface GuiNumberMessage {
   uuid: string;
   value: number;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    precision: number;
-    step: number;
-    min: number | null;
-    max: number | null;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'precision': number, 'step': number, 'min': (number | null), 'max': (number | null)};
 }
 /** GuiRgbMessage(uuid: 'str', value: 'Tuple[int, int, int]', container_uuid: 'str', props: 'GuiRgbProps')
  *
@@ -883,13 +398,7 @@ export interface GuiRgbMessage {
   uuid: string;
   value: [number, number, number];
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean};
 }
 /** GuiRgbaMessage(uuid: 'str', value: 'Tuple[int, int, int, int]', container_uuid: 'str', props: 'GuiRgbaProps')
  *
@@ -900,13 +409,7 @@ export interface GuiRgbaMessage {
   uuid: string;
   value: [number, number, number, number];
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean};
 }
 /** GuiCheckboxMessage(uuid: 'str', value: 'bool', container_uuid: 'str', props: 'GuiCheckboxProps')
  *
@@ -917,13 +420,7 @@ export interface GuiCheckboxMessage {
   uuid: string;
   value: boolean;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean};
 }
 /** GuiVector2Message(uuid: 'str', value: 'Tuple[float, float]', container_uuid: 'str', props: 'GuiVector2Props')
  *
@@ -934,17 +431,7 @@ export interface GuiVector2Message {
   uuid: string;
   value: [number, number];
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    min: [number, number] | null;
-    max: [number, number] | null;
-    step: number;
-    precision: number;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'min': ([number, number] | null), 'max': ([number, number] | null), 'step': number, 'precision': number};
 }
 /** GuiVector3Message(uuid: 'str', value: 'Tuple[float, float, float]', container_uuid: 'str', props: 'GuiVector3Props')
  *
@@ -955,17 +442,7 @@ export interface GuiVector3Message {
   uuid: string;
   value: [number, number, number];
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    min: [number, number, number] | null;
-    max: [number, number, number] | null;
-    step: number;
-    precision: number;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'min': ([number, number, number] | null), 'max': ([number, number, number] | null), 'step': number, 'precision': number};
 }
 /** GuiTextMessage(uuid: 'str', value: 'str', container_uuid: 'str', props: 'GuiTextProps')
  *
@@ -976,14 +453,7 @@ export interface GuiTextMessage {
   uuid: string;
   value: string;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    multiline: boolean;
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'multiline': boolean};
 }
 /** GuiDropdownMessage(uuid: 'str', value: 'str', container_uuid: 'str', props: 'GuiDropdownProps')
  *
@@ -994,14 +464,7 @@ export interface GuiDropdownMessage {
   uuid: string;
   value: string;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    options: string[];
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'options': string[]};
 }
 /** GuiButtonGroupMessage(uuid: 'str', value: 'str', container_uuid: 'str', props: 'GuiButtonGroupProps')
  *
@@ -1012,14 +475,7 @@ export interface GuiButtonGroupMessage {
   uuid: string;
   value: string;
   container_uuid: string;
-  props: {
-    order: number;
-    label: string;
-    hint: string | null;
-    visible: boolean;
-    disabled: boolean;
-    options: string[];
-  };
+  props: {'order': number, 'label': string, 'hint': (string | null), 'visible': boolean, 'disabled': boolean, 'options': string[]};
 }
 /** Sent server->client to remove a GUI element.
  *
@@ -1045,32 +501,9 @@ export interface RunJavascriptMessage {
  */
 export interface NotificationMessage {
   type: "NotificationMessage";
-  mode: "show" | "update";
+  mode: 'show' | 'update';
   uuid: string;
-  props: {
-    title: string;
-    body: string;
-    loading: boolean;
-    with_close_button: boolean;
-    auto_close_seconds: number | null;
-    color:
-      | "dark"
-      | "gray"
-      | "red"
-      | "pink"
-      | "grape"
-      | "violet"
-      | "indigo"
-      | "blue"
-      | "cyan"
-      | "green"
-      | "lime"
-      | "yellow"
-      | "orange"
-      | "teal"
-      | [number, number, number]
-      | null;
-  };
+  props: {'title': string, 'body': string, 'loading': boolean, 'with_close_button': boolean, 'auto_close_seconds': (number | null), 'color': ('dark' | 'gray' | 'red' | 'pink' | 'grape' | 'violet' | 'indigo' | 'blue' | 'cyan' | 'green' | 'lime' | 'yellow' | 'orange' | 'teal' | [number, number, number] | null)};
 }
 /** Remove a specific notification.
  *
@@ -1100,15 +533,15 @@ export interface ViewerCameraMessage {
 /** Message for a raycast-like pointer in the scene.
  * origin is the viewing camera position, in world coordinates.
  * direction is the vector if a ray is projected from the camera through the clicked pixel,
- *
+ * 
  *
  * (automatically generated)
  */
 export interface ScenePointerMessage {
   type: "ScenePointerMessage";
-  event_type: "click" | "rect-select";
-  ray_origin: [number, number, number] | null;
-  ray_direction: [number, number, number] | null;
+  event_type: 'click' | 'rect-select';
+  ray_origin: ([number, number, number] | null);
+  ray_direction: ([number, number, number] | null);
   screen_pos: [number, number][];
 }
 /** Message to enable/disable scene click events.
@@ -1118,7 +551,7 @@ export interface ScenePointerMessage {
 export interface ScenePointerEnableMessage {
   type: "ScenePointerEnableMessage";
   enable: boolean;
-  event_type: "click" | "rect-select";
+  event_type: 'click' | 'rect-select';
 }
 /** Environment Map message.
  *
@@ -1126,18 +559,7 @@ export interface ScenePointerEnableMessage {
  */
 export interface EnvironmentMapMessage {
   type: "EnvironmentMapMessage";
-  hdri:
-    | "apartment"
-    | "city"
-    | "dawn"
-    | "forest"
-    | "lobby"
-    | "night"
-    | "park"
-    | "studio"
-    | "sunset"
-    | "warehouse"
-    | null;
+  hdri: ('apartment' | 'city' | 'dawn' | 'forest' | 'lobby' | 'night' | 'park' | 'studio' | 'sunset' | 'warehouse' | null);
   background: boolean;
   background_blurriness: number;
   background_intensity: number;
@@ -1155,7 +577,7 @@ export interface EnableLightsMessage {
   cast_shadow: boolean;
 }
 /** Server -> client message to set a skinned mesh bone's orientation.
- *
+ * 
  * As with all other messages, transforms take the `T_parent_local` convention.
  *
  * (automatically generated)
@@ -1167,7 +589,7 @@ export interface SetBoneOrientationMessage {
   wxyz: [number, number, number, number];
 }
 /** Server -> client message to set a skinned mesh bone's position.
- *
+ * 
  * As with all other messages, transforms take the `T_parent_local` convention.
  *
  * (automatically generated)
@@ -1227,7 +649,7 @@ export interface SetCameraFovMessage {
   fov: number;
 }
 /** Server -> client message to set a scene node's orientation.
- *
+ * 
  * As with all other messages, transforms take the `T_parent_local` convention.
  *
  * (automatically generated)
@@ -1238,7 +660,7 @@ export interface SetOrientationMessage {
   wxyz: [number, number, number, number];
 }
 /** Server -> client message to set a scene node's position.
- *
+ * 
  * As with all other messages, transforms take the `T_parent_local` convention.
  *
  * (automatically generated)
@@ -1249,7 +671,7 @@ export interface SetPositionMessage {
   position: [number, number, number];
 }
 /** Client -> server message when a transform control is updated.
- *
+ * 
  * As with all other messages, transforms take the `T_parent_local` convention.
  *
  * (automatically generated)
@@ -1282,9 +704,9 @@ export interface TransformControlsDragEndMessage {
  */
 export interface BackgroundImageMessage {
   type: "BackgroundImageMessage";
-  media_type: "image/jpeg" | "image/png";
-  rgb_data: Uint8Array | null;
-  depth_data: Uint8Array | null;
+  format: 'jpeg' | 'png';
+  rgb_data: (Uint8Array | null);
+  depth_data: (Uint8Array | null);
 }
 /** Set the visibility of a particular node in the scene.
  *
@@ -1311,7 +733,7 @@ export interface SetSceneNodeClickableMessage {
 export interface SceneNodeClickMessage {
   type: "SceneNodeClickMessage";
   name: string;
-  instance_index: number | null;
+  instance_index: (number | null);
   ray_origin: [number, number, number];
   ray_direction: [number, number, number];
   screen_pos: [number, number];
@@ -1348,7 +770,7 @@ export interface GuiCloseModalMessage {
 export interface GuiUpdateMessage {
   type: "GuiUpdateMessage";
   uuid: string;
-  updates: { [key: string]: any };
+  updates: {[key: string]: any};
 }
 /** Sent client<->server when any property of a scene node is changed.
  *
@@ -1357,7 +779,7 @@ export interface GuiUpdateMessage {
 export interface SceneNodeUpdateMessage {
   type: "SceneNodeUpdateMessage";
   name: string;
-  updates: { [key: string]: any };
+  updates: {[key: string]: any};
 }
 /** Message from server->client to configure parts of the GUI.
  *
@@ -1365,40 +787,13 @@ export interface SceneNodeUpdateMessage {
  */
 export interface ThemeConfigurationMessage {
   type: "ThemeConfigurationMessage";
-  titlebar_content: {
-    buttons:
-      | {
-          text: string | null;
-          icon: "GitHub" | "Description" | "Keyboard" | null;
-          href: string | null;
-        }[]
-      | null;
-    image: {
-      image_url_light: string;
-      image_url_dark: string | null;
-      image_alt: string;
-      href: string | null;
-    } | null;
-  } | null;
-  control_layout: "floating" | "collapsible" | "fixed";
-  control_width: "small" | "medium" | "large";
+  titlebar_content: ({'buttons': ({'text': (string | null), 'icon': ('GitHub' | 'Description' | 'Keyboard' | null), 'href': (string | null)}[] | null), 'image': ({'image_url_light': string, 'image_url_dark': (string | null), 'image_alt': string, 'href': (string | null)} | null)} | null);
+  control_layout: 'floating' | 'collapsible' | 'fixed';
+  control_width: 'small' | 'medium' | 'large';
   show_logo: boolean;
   show_share_button: boolean;
   dark_mode: boolean;
-  colors:
-    | [
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-        string,
-      ]
-    | null;
+  colors: ([string, string, string, string, string, string, string, string, string, string] | null);
 }
 /** Message from server->client requesting a render from a specified camera
  * pose.
@@ -1407,7 +802,7 @@ export interface ThemeConfigurationMessage {
  */
 export interface GetRenderRequestMessage {
   type: "GetRenderRequestMessage";
-  format: "image/jpeg" | "image/png";
+  format: 'image/jpeg' | 'image/png';
   height: number;
   width: number;
   quality: number;
@@ -1424,9 +819,9 @@ export interface GetRenderResponseMessage {
   payload: Uint8Array;
 }
 /** Signal that a file is about to be sent.
- *
+ * 
  * This message is used to upload files from clients to the server.
- *
+ * 
  *
  * (automatically generated)
  */
@@ -1440,9 +835,9 @@ export interface FileTransferStartUpload {
   size_bytes: number;
 }
 /** Signal that a file is about to be sent.
- *
+ * 
  * This message is used to send files to clients from the server.
- *
+ * 
  *
  * (automatically generated)
  */
@@ -1461,7 +856,7 @@ export interface FileTransferStartDownload {
  */
 export interface FileTransferPart {
   type: "FileTransferPart";
-  source_component_uuid: string | null;
+  source_component_uuid: (string | null);
   transfer_uuid: string;
   part_index: number;
   content: Uint8Array;
@@ -1472,7 +867,7 @@ export interface FileTransferPart {
  */
 export interface FileTransferPartAck {
   type: "FileTransferPartAck";
-  source_component_uuid: string | null;
+  source_component_uuid: (string | null);
   transfer_uuid: string;
   transferred_bytes: number;
   total_bytes: number;
@@ -1490,7 +885,7 @@ export interface ShareUrlRequest {
  */
 export interface ShareUrlUpdated {
   type: "ShareUrlUpdated";
-  share_url: string | null;
+  share_url: (string | null);
 }
 /** Message from client->server to disconnect from the share URL server.
  *
@@ -1505,10 +900,10 @@ export interface ShareUrlDisconnect {
  */
 export interface SetGuiPanelLabelMessage {
   type: "SetGuiPanelLabelMessage";
-  label: string | null;
+  label: (string | null);
 }
 
-export type Message =
+export type Message = 
   | CameraFrustumMessage
   | GlbMessage
   | FrameMessage
@@ -1599,7 +994,7 @@ export type Message =
   | ShareUrlUpdated
   | ShareUrlDisconnect
   | SetGuiPanelLabelMessage;
-export type SceneNodeMessage =
+export type SceneNodeMessage = 
   | CameraFrustumMessage
   | GlbMessage
   | FrameMessage
@@ -1626,7 +1021,7 @@ export type SceneNodeMessage =
   | CatmullRomSplineMessage
   | CubicBezierSplineMessage
   | GaussianSplatsMessage;
-export type GuiComponentMessage =
+export type GuiComponentMessage = 
   | GuiFolderMessage
   | GuiMarkdownMessage
   | GuiHtmlMessage
@@ -1648,64 +1043,9 @@ export type GuiComponentMessage =
   | GuiTextMessage
   | GuiDropdownMessage
   | GuiButtonGroupMessage;
-const typeSetSceneNodeMessage = new Set([
-  "CameraFrustumMessage",
-  "GlbMessage",
-  "FrameMessage",
-  "BatchedAxesMessage",
-  "GridMessage",
-  "LabelMessage",
-  "Gui3DMessage",
-  "PointCloudMessage",
-  "DirectionalLightMessage",
-  "AmbientLightMessage",
-  "HemisphereLightMessage",
-  "PointLightMessage",
-  "RectAreaLightMessage",
-  "SpotLightMessage",
-  "MeshMessage",
-  "BoxMessage",
-  "IcosphereMessage",
-  "SkinnedMeshMessage",
-  "BatchedMeshesMessage",
-  "BatchedGlbMessage",
-  "TransformControlsMessage",
-  "ImageMessage",
-  "LineSegmentsMessage",
-  "CatmullRomSplineMessage",
-  "CubicBezierSplineMessage",
-  "GaussianSplatsMessage",
-]);
-export function isSceneNodeMessage(
-  message: Message,
-): message is SceneNodeMessage {
-  return typeSetSceneNodeMessage.has(message.type);
+const typeSetSceneNodeMessage = new Set(['CameraFrustumMessage', 'GlbMessage', 'FrameMessage', 'BatchedAxesMessage', 'GridMessage', 'LabelMessage', 'Gui3DMessage', 'PointCloudMessage', 'DirectionalLightMessage', 'AmbientLightMessage', 'HemisphereLightMessage', 'PointLightMessage', 'RectAreaLightMessage', 'SpotLightMessage', 'MeshMessage', 'BoxMessage', 'IcosphereMessage', 'SkinnedMeshMessage', 'BatchedMeshesMessage', 'BatchedGlbMessage', 'TransformControlsMessage', 'ImageMessage', 'LineSegmentsMessage', 'CatmullRomSplineMessage', 'CubicBezierSplineMessage', 'GaussianSplatsMessage']);export function isSceneNodeMessage(message: Message): message is SceneNodeMessage {
+    return typeSetSceneNodeMessage.has(message.type);
 }
-const typeSetGuiComponentMessage = new Set([
-  "GuiFolderMessage",
-  "GuiMarkdownMessage",
-  "GuiHtmlMessage",
-  "GuiProgressBarMessage",
-  "GuiPlotlyMessage",
-  "GuiUplotMessage",
-  "GuiImageMessage",
-  "GuiTabGroupMessage",
-  "GuiButtonMessage",
-  "GuiUploadButtonMessage",
-  "GuiSliderMessage",
-  "GuiMultiSliderMessage",
-  "GuiNumberMessage",
-  "GuiRgbMessage",
-  "GuiRgbaMessage",
-  "GuiCheckboxMessage",
-  "GuiVector2Message",
-  "GuiVector3Message",
-  "GuiTextMessage",
-  "GuiDropdownMessage",
-  "GuiButtonGroupMessage",
-]);
-export function isGuiComponentMessage(
-  message: Message,
-): message is GuiComponentMessage {
-  return typeSetGuiComponentMessage.has(message.type);
+const typeSetGuiComponentMessage = new Set(['GuiFolderMessage', 'GuiMarkdownMessage', 'GuiHtmlMessage', 'GuiProgressBarMessage', 'GuiPlotlyMessage', 'GuiUplotMessage', 'GuiImageMessage', 'GuiTabGroupMessage', 'GuiButtonMessage', 'GuiUploadButtonMessage', 'GuiSliderMessage', 'GuiMultiSliderMessage', 'GuiNumberMessage', 'GuiRgbMessage', 'GuiRgbaMessage', 'GuiCheckboxMessage', 'GuiVector2Message', 'GuiVector3Message', 'GuiTextMessage', 'GuiDropdownMessage', 'GuiButtonGroupMessage']);export function isGuiComponentMessage(message: Message): message is GuiComponentMessage {
+    return typeSetGuiComponentMessage.has(message.type);
 }

--- a/src/viser/client/src/components/Image.tsx
+++ b/src/viser/client/src/components/Image.tsx
@@ -12,14 +12,14 @@ function ImageComponent({ props }: GuiImageMessage) {
       setImageUrl(null);
     } else {
       const image_url = URL.createObjectURL(
-        new Blob([props._data], { type: props.media_type }),
+        new Blob([props._data], { type: "image/" + props.format }),
       );
       setImageUrl(image_url);
       return () => {
         URL.revokeObjectURL(image_url);
       };
     }
-  }, [props._data, props.media_type]);
+  }, [props._data, props.format]);
 
   return imageUrl === null ? null : (
     <Box px="xs">

--- a/sync_client_server.py
+++ b/sync_client_server.py
@@ -11,86 +11,100 @@ import pathlib
 import subprocess
 import urllib.request
 
+import tyro
+
 import viser
 import viser.infra
 from viser._messages import Message
 
-if __name__ == "__main__":
-    # Generate TypeScript message interfaces
-    defs = viser.infra.generate_typescript_interfaces(Message)
 
-    # Write message interfaces to file
-    target_path = pathlib.Path(__file__).parent / pathlib.Path(
-        "src/viser/client/src/WebsocketMessages.ts"
-    )
-    # Create directory if it doesn't exist
-    target_path.parent.mkdir(parents=True, exist_ok=True)
+def main(sync_messages: bool = True, sync_version: bool = True) -> None:
+    if sync_messages:
+        # Generate TypeScript message interfaces
+        defs = viser.infra.generate_typescript_interfaces(Message)
 
-    # Write to file even if it doesn't exist yet
-    target_path.write_text(defs)
-    print(f"{target_path} updated")
-
-    # Generate version and contributors information file
-    version_path = pathlib.Path(__file__).parent / pathlib.Path(
-        "src/viser/client/src/VersionInfo.ts"
-    )
-    # Create directory if it doesn't exist
-    version_path.parent.mkdir(parents=True, exist_ok=True)
-
-    # Try to fetch contributors from GitHub API
-    contributors_data = []
-    try:
-        # GitHub API endpoint for contributors
-        api_url = "https://api.github.com/repos/nerfstudio-project/viser/contributors"
-        req = urllib.request.Request(
-            api_url,
-            headers={
-                "User-Agent": "viser-sync-script",
-                "Accept": "application/vnd.github.v3+json",
-            },
+        # Write message interfaces to file
+        target_path = pathlib.Path(__file__).parent / pathlib.Path(
+            "src/viser/client/src/WebsocketMessages.ts"
         )
-        with urllib.request.urlopen(req) as response:
-            contributors_json = json.loads(response.read().decode())
+        # Create directory if it doesn't exist
+        target_path.parent.mkdir(parents=True, exist_ok=True)
 
-            # Extract relevant contributor information
-            for contributor in contributors_json:
-                if isinstance(contributor, dict) and contributor.get("type") == "User":
-                    contributors_data.append(
-                        {
-                            "login": contributor.get("login", ""),
-                            "html_url": contributor.get("html_url", ""),
-                        }
-                    )
+        # Write to file even if it doesn't exist yet
+        target_path.write_text(defs)
+        print(f"{target_path} updated")
 
-            print(f"Fetched {len(contributors_data)} contributors from GitHub")
-    except Exception as e:
-        print(f"Warning: Failed to fetch contributors from GitHub: {e}")
-        print("Skipping version and contributors info.")
-
-    if len(contributors_data) > 0:
-        # Generate combined version and contributors file
-        version_content = f"""// Automatically generated file - do not edit manually.
-    // This is synchronized with the Python package version in viser/__init__.py.
-    export const VISER_VERSION = "{viser.__version__}";
-
-    // GitHub contributors for the viser project.
-    export interface Contributor {{
-      login: string;
-      html_url: string;
-    }}
-
-    export const GITHUB_CONTRIBUTORS: Contributor[] = {json.dumps(contributors_data, indent=2)};
-    """
-        version_path.write_text(version_content)
-        print(f"Version and contributors info generated: {version_path}")
-
-    # Run prettier on all generated files if it's available
-    try:
-        subprocess.run(
-            args=["npx", "prettier", "-w", str(target_path), str(version_path)],
-            check=False,
+    if sync_version:
+        # Generate version and contributors information file
+        version_path = pathlib.Path(__file__).parent / pathlib.Path(
+            "src/viser/client/src/VersionInfo.ts"
         )
-    except FileNotFoundError:
-        print("Warning: npx/prettier not found, skipping formatting")
+        # Create directory if it doesn't exist
+        version_path.parent.mkdir(parents=True, exist_ok=True)
+
+        # Try to fetch contributors from GitHub API
+        contributors_data = []
+        try:
+            # GitHub API endpoint for contributors
+            api_url = (
+                "https://api.github.com/repos/nerfstudio-project/viser/contributors"
+            )
+            req = urllib.request.Request(
+                api_url,
+                headers={
+                    "User-Agent": "viser-sync-script",
+                    "Accept": "application/vnd.github.v3+json",
+                },
+            )
+            with urllib.request.urlopen(req) as response:
+                contributors_json = json.loads(response.read().decode())
+
+                # Extract relevant contributor information
+                for contributor in contributors_json:
+                    if (
+                        isinstance(contributor, dict)
+                        and contributor.get("type") == "User"
+                    ):
+                        contributors_data.append(
+                            {
+                                "login": contributor.get("login", ""),
+                                "html_url": contributor.get("html_url", ""),
+                            }
+                        )
+
+                print(f"Fetched {len(contributors_data)} contributors from GitHub")
+        except Exception as e:
+            print(f"Warning: Failed to fetch contributors from GitHub: {e}")
+            print("Skipping version and contributors info.")
+
+        if len(contributors_data) > 0:
+            # Generate combined version and contributors file
+            version_content = f"""// Automatically generated file - do not edit manually.
+        // This is synchronized with the Python package version in viser/__init__.py.
+        export const VISER_VERSION = "{viser.__version__}";
+
+        // GitHub contributors for the viser project.
+        export interface Contributor {{
+          login: string;
+          html_url: string;
+        }}
+
+        export const GITHUB_CONTRIBUTORS: Contributor[] = {json.dumps(contributors_data, indent=2)};
+        """
+            version_path.write_text(version_content)
+            print(f"Version and contributors info generated: {version_path}")
+
+        # Run prettier on all generated files if it's available
+        try:
+            subprocess.run(
+                args=["npx", "prettier", "-w", str(target_path), str(version_path)],
+                check=False,
+            )
+        except FileNotFoundError:
+            print("Warning: npx/prettier not found, skipping formatting")
 
     print("Synchronization complete")
+
+
+if __name__ == "__main__":
+    tyro.cli(main)


### PR DESCRIPTION
Addresses #511 by handling RGBA image when using OpenCV for encoding images!

There are some "soft" breaking changes here; the core API is unchanged (`add_image`, `add_camera_frustum`, etc), but:
- I renamed the `media_type` props to `format` for consistency with the `add_...` signatures.
- I introduced some more consistent but different edge case behavior. Notably: the `format` argument (defaults to `jpeg`) was formerly ignored if `image` was set to `None`. If the image was set later, the default format was `png`. We now (i) persist the original format argument the same way we persist all other props/args and (ii) default to `jpeg` in both cases.

Probably this is okay, but will think about it a bit before merging.