### PR TITLE
Fix mesh mounting bottlenecks caused by hover outlines

### DIFF
--- a/src/viser/client/src/App.tsx
+++ b/src/viser/client/src/App.tsx
@@ -6,7 +6,7 @@ import "./index.css";
 
 import { useInView } from "react-intersection-observer";
 import { Notifications } from "@mantine/notifications";
-import { Environment, PerformanceMonitor, Stats, Bvh } from "@react-three/drei";
+import { Environment, PerformanceMonitor, Stats } from "@react-three/drei";
 import * as THREE from "three";
 import { Canvas, useThree, useFrame } from "@react-three/fiber";
 import React, { useEffect, useMemo } from "react";
@@ -487,7 +487,7 @@ function ViewerCanvas({ children }: { children: React.ReactNode }) {
   const fixedDpr = viewer.useDevSettings((state) => state.fixedDpr);
   const sceneContents = React.useMemo(
     () => (
-      <Bvh firstHitOnly>
+      <>
         <BackgroundImage />
         <SceneContextSetter />
         {memoizedCameraControls}
@@ -497,7 +497,7 @@ function ViewerCanvas({ children }: { children: React.ReactNode }) {
           <SceneNodeThreeObject name="" />
         </SplatRenderContext>
         <DefaultLights />
-      </Bvh>
+      </>
     ),
     [children, memoizedCameraControls],
   );

--- a/src/viser/client/src/CameraFrustumVariants.tsx
+++ b/src/viser/client/src/CameraFrustumVariants.tsx
@@ -43,12 +43,15 @@ export const CameraFrustumComponent = React.forwardRef<
   y *= message.props.scale;
   z *= message.props.scale;
 
-  const hoveredRef = React.useContext(HoverableContext);
+  const hoverContext = React.useContext(HoverableContext);
   const [isHovered, setIsHovered] = React.useState(false);
 
   useFrame(() => {
-    if (hoveredRef !== null && hoveredRef.current.isHovered !== isHovered) {
-      setIsHovered(hoveredRef.current.isHovered);
+    if (
+      hoverContext !== null &&
+      hoverContext.state.current.isHovered !== isHovered
+    ) {
+      setIsHovered(hoverContext.state.current.isHovered);
     }
   });
 

--- a/src/viser/client/src/HoverContext.ts
+++ b/src/viser/client/src/HoverContext.ts
@@ -6,5 +6,7 @@ export interface HoverState {
   instanceId: number | null;
 }
 
-export const HoverableContext =
-  React.createContext<React.MutableRefObject<HoverState> | null>(null);
+export const HoverableContext = React.createContext<{
+  state: React.MutableRefObject<HoverState>;
+  clickable: boolean;
+} | null>(null);

--- a/src/viser/client/src/OutlinesIfHovered.tsx
+++ b/src/viser/client/src/OutlinesIfHovered.tsx
@@ -35,10 +35,10 @@ function _OutlinesIfHovered(props: {
     if (props.unmountOnHide) {
       if (mounted !== hoverContext.state.current.isHovered)
         setMounted(hoverContext.state.current.isHovered);
-    } else if (hoverContext.state.current.isHovered != mounted) {
-      if (groupRef.current === null) return;
-      groupRef.current.visible = hoverContext.state.current.isHovered;
+      return;
     }
+    if (groupRef.current !== null)
+      groupRef.current.visible = hoverContext.state.current.isHovered;
   });
 
   return !mounted ? null : (

--- a/src/viser/client/src/OutlinesIfHovered.tsx
+++ b/src/viser/client/src/OutlinesIfHovered.tsx
@@ -26,17 +26,18 @@ function _OutlinesIfHovered(props: {
 }) {
   const groupRef = React.useRef<THREE.Group>(null);
   const hoverContext = React.useContext(HoverableContext);
-  const [mounted, setMounted] = React.useState(true);
+  const [mounted, setMounted] = React.useState(false);
 
   const creaseAngle = props.enableCreaseAngle ? Math.PI : 0.0;
 
   useFrame(() => {
     if (hoverContext === null || !hoverContext.clickable) return;
-    if (!props.unmountOnHide) {
+    if (props.unmountOnHide) {
+      if (mounted !== hoverContext.state.current.isHovered)
+        setMounted(hoverContext.state.current.isHovered);
+    } else if (hoverContext.state.current.isHovered != mounted) {
       if (groupRef.current === null) return;
       groupRef.current.visible = hoverContext.state.current.isHovered;
-    } else if (hoverContext.state.current.isHovered != mounted) {
-      setMounted(hoverContext.state.current.isHovered);
     }
   });
 

--- a/src/viser/client/src/OutlinesIfHovered.tsx
+++ b/src/viser/client/src/OutlinesIfHovered.tsx
@@ -11,10 +11,7 @@ export function OutlinesIfHovered(
     unmountOnHide?: boolean;
     enableCreaseAngle?: boolean;
   } = {
-    // Can be set to true for objects like meshes which may be slow to mount.
-    // It seems better to set to False for instanced meshes, there may be some
-    // drei or fiber-related race conditions...
-    unmountOnHide: false,
+    unmountOnHide: false, // Useful when outlines are combined with <Instances />.
     enableCreaseAngle: false,
   },
 ) {

--- a/src/viser/client/src/OutlinesIfHovered.tsx
+++ b/src/viser/client/src/OutlinesIfHovered.tsx
@@ -7,29 +7,43 @@ import * as THREE from "three";
 /** Outlines object, which should be placed as a child of all meshes that might
  * be clickable. */
 export function OutlinesIfHovered(
-  props: { alwaysMounted?: boolean; creaseAngle?: number } = {
+  props: {
+    unmountOnHide?: boolean;
+    enableCreaseAngle?: boolean;
+  } = {
     // Can be set to true for objects like meshes which may be slow to mount.
     // It seems better to set to False for instanced meshes, there may be some
     // drei or fiber-related race conditions...
-    alwaysMounted: false,
-    // Some thing just look better with no creasing, like camera frustum objects.
-    creaseAngle: Math.PI,
+    unmountOnHide: false,
+    enableCreaseAngle: false,
   },
 ) {
+  const hoverContext = React.useContext(HoverableContext);
+  if (hoverContext === null || !hoverContext.clickable) return null;
+  return <_OutlinesIfHovered {...props} />;
+}
+
+function _OutlinesIfHovered(props: {
+  unmountOnHide?: boolean;
+  enableCreaseAngle?: boolean;
+}) {
   const groupRef = React.useRef<THREE.Group>(null);
-  const hoveredRef = React.useContext(HoverableContext);
+  const hoverContext = React.useContext(HoverableContext);
   const [mounted, setMounted] = React.useState(true);
 
+  const creaseAngle = props.enableCreaseAngle ? Math.PI : 0.0;
+
   useFrame(() => {
-    if (hoveredRef === null) return;
-    if (props.alwaysMounted) {
+    if (hoverContext === null || !hoverContext.clickable) return;
+    if (!props.unmountOnHide) {
       if (groupRef.current === null) return;
-      groupRef.current.visible = hoveredRef.current.isHovered;
-    } else if (hoveredRef.current.isHovered != mounted) {
-      setMounted(hoveredRef.current.isHovered);
+      groupRef.current.visible = hoverContext.state.current.isHovered;
+    } else if (hoverContext.state.current.isHovered != mounted) {
+      setMounted(hoverContext.state.current.isHovered);
     }
   });
-  return hoveredRef === null || !mounted ? null : (
+
+  return !mounted ? null : (
     <Outlines
       ref={groupRef}
       thickness={10}
@@ -37,7 +51,7 @@ export function OutlinesIfHovered(
       color={0xfbff00}
       opacity={0.8}
       transparent={true}
-      angle={props.creaseAngle}
+      angle={creaseAngle}
     />
   );
 }

--- a/src/viser/client/src/OutlinesIfHovered.tsx
+++ b/src/viser/client/src/OutlinesIfHovered.tsx
@@ -26,7 +26,7 @@ function _OutlinesIfHovered(props: {
 }) {
   const groupRef = React.useRef<THREE.Group>(null);
   const hoverContext = React.useContext(HoverableContext);
-  const [mounted, setMounted] = React.useState(false);
+  const [mounted, setMounted] = React.useState(true);
 
   const creaseAngle = props.enableCreaseAngle ? Math.PI : 0.0;
 

--- a/src/viser/client/src/SceneTree.tsx
+++ b/src/viser/client/src/SceneTree.tsx
@@ -1006,7 +1006,7 @@ export function SceneNodeThreeObject(props: { name: string }) {
                 }
           }
         >
-          <HoverableContext.Provider value={hoveredRef}>
+          <HoverableContext.Provider value={{ state: hoveredRef, clickable }}>
             {objNode}
           </HoverableContext.Provider>
         </group>

--- a/src/viser/client/src/ThreeAssets.tsx
+++ b/src/viser/client/src/ThreeAssets.tsx
@@ -205,7 +205,7 @@ export const CoordinateFrame = React.forwardRef<
             <meshBasicMaterial color={originColor} />
             <OutlinesIfHovered />
           </mesh>
-          <Instances limit={3}>
+          <Instances limit={6}>
             <meshBasicMaterial />
             <cylinderGeometry args={[axesRadius, axesRadius, axesLength, 16]} />
             <Instance
@@ -213,17 +213,18 @@ export const CoordinateFrame = React.forwardRef<
               position={[0.5 * axesLength, 0.0, 0.0]}
               color={0xcc0000}
             >
-              <OutlinesIfHovered />
+              {/* unmountOnHide is needed to use OutlineIfHovered within <Instances />. */}
+              <OutlinesIfHovered unmountOnHide enableCreaseAngle />
             </Instance>
             <Instance position={[0.0, 0.5 * axesLength, 0.0]} color={0x00cc00}>
-              <OutlinesIfHovered />
+              <OutlinesIfHovered unmountOnHide enableCreaseAngle />
             </Instance>
             <Instance
               rotation={new THREE.Euler(Math.PI / 2.0, 0.0, 0.0)}
               position={[0.0, 0.0, 0.5 * axesLength]}
               color={0x0000cc}
             >
-              <OutlinesIfHovered />
+              <OutlinesIfHovered unmountOnHide enableCreaseAngle />
             </Instance>
           </Instances>
         </>

--- a/src/viser/client/src/mesh/BasicMesh.tsx
+++ b/src/viser/client/src/mesh/BasicMesh.tsx
@@ -81,7 +81,10 @@ export const BasicMesh = React.forwardRef<
       receiveShadow={message.props.receive_shadow}
     >
       <OutlinesIfHovered
-        enableCreaseAngle={geometry.attributes.position.count < 1024}
+        enableCreaseAngle={
+          geometry.attributes.position.count < 1024 &&
+          geometry.boundingSphere!.radius > 0.1
+        }
       />
       {children}
     </mesh>

--- a/src/viser/client/src/mesh/BasicMesh.tsx
+++ b/src/viser/client/src/mesh/BasicMesh.tsx
@@ -80,7 +80,9 @@ export const BasicMesh = React.forwardRef<
       castShadow={message.props.cast_shadow}
       receiveShadow={message.props.receive_shadow}
     >
-      <OutlinesIfHovered alwaysMounted />
+      <OutlinesIfHovered
+        enableCreaseAngle={geometry.attributes.position.count < 1024}
+      />
       {children}
     </mesh>
   );

--- a/src/viser/client/src/mesh/BatchedMeshHoverOutlines.tsx
+++ b/src/viser/client/src/mesh/BatchedMeshHoverOutlines.tsx
@@ -51,14 +51,13 @@ export const BatchedMeshHoverOutlines: React.FC<
   computeBatchIndexFromInstanceIndex,
 }) => {
   // Get hover state from context.
-  const hoveredRef = React.useContext(HoverableContext)!;
+  const hoverContext = React.useContext(HoverableContext)!;
 
   // Create outline mesh reference.
   const outlineRef = React.useRef<THREE.Mesh>(null);
 
   // Get rendering context for screen size.
-  const gl = useThree((state) => state.gl);
-  const contextSize = React.useMemo(
+  const gl = useThree((state) => state.gl); const contextSize = React.useMemo(
     () => gl.getDrawingBufferSize(new THREE.Vector2()),
     [gl],
   );
@@ -109,18 +108,18 @@ export const BatchedMeshHoverOutlines: React.FC<
 
   // Update outline position based on hover state.
   useFrame(() => {
-    if (!outlineRef.current || !outlineGeometry || !hoveredRef) return;
+    if (!outlineRef.current || !outlineGeometry || !hoverContext) return;
 
     // Hide by default.
     outlineRef.current.visible = false;
 
     // Check if we're hovering and have a valid instanceId.
     if (
-      hoveredRef.current.isHovered &&
-      hoveredRef.current.instanceId !== null
+      hoverContext.state.current.isHovered &&
+      hoverContext.state.current.instanceId !== null
     ) {
       // Get the instance ID from the hover state.
-      const hoveredInstanceId = hoveredRef.current.instanceId;
+      const hoveredInstanceId = hoverContext.state.current.instanceId;
 
       // Calculate the actual batch index using the mapping function if provided.
       const batchIndex = computeBatchIndexFromInstanceIndex
@@ -235,7 +234,7 @@ export const BatchedMeshHoverOutlines: React.FC<
 
   // This is now handled by the earlier cleanup effect.
 
-  if (!hoveredRef || !outlineGeometry) {
+  if (!hoverContext || !hoverContext.clickable || !outlineGeometry) {
     return null;
   }
 

--- a/src/viser/client/src/mesh/BatchedMeshHoverOutlines.tsx
+++ b/src/viser/client/src/mesh/BatchedMeshHoverOutlines.tsx
@@ -57,7 +57,8 @@ export const BatchedMeshHoverOutlines: React.FC<
   const outlineRef = React.useRef<THREE.Mesh>(null);
 
   // Get rendering context for screen size.
-  const gl = useThree((state) => state.gl); const contextSize = React.useMemo(
+  const gl = useThree((state) => state.gl);
+  const contextSize = React.useMemo(
     () => gl.getDrawingBufferSize(new THREE.Vector2()),
     [gl],
   );

--- a/src/viser/client/src/mesh/BoxMesh.tsx
+++ b/src/viser/client/src/mesh/BoxMesh.tsx
@@ -49,7 +49,7 @@ export const BoxMesh = React.forwardRef<
         castShadow={message.props.cast_shadow}
         receiveShadow={message.props.receive_shadow}
       >
-        <OutlinesIfHovered alwaysMounted />
+        <OutlinesIfHovered enableCreaseAngle />
       </mesh>
       {children}
     </group>

--- a/src/viser/client/src/mesh/IcosphereMesh.tsx
+++ b/src/viser/client/src/mesh/IcosphereMesh.tsx
@@ -66,7 +66,7 @@ export const IcosphereMesh = React.forwardRef<
         castShadow={message.props.cast_shadow}
         receiveShadow={message.props.receive_shadow}
       >
-        <OutlinesIfHovered alwaysMounted />
+        <OutlinesIfHovered />
       </mesh>
       {children}
     </group>

--- a/src/viser/client/src/mesh/SingleGlbAsset.tsx
+++ b/src/viser/client/src/mesh/SingleGlbAsset.tsx
@@ -5,7 +5,6 @@ import { useGlbLoader } from "./GlbLoaderUtils";
 import { useFrame, useThree } from "@react-three/fiber";
 import { HoverableContext } from "../HoverContext";
 import { OutlinesMaterial } from "../Outlines";
-import { ViewerContext } from "../ViewerContext";
 
 /**
  * Component for rendering a single GLB model
@@ -59,14 +58,12 @@ export const SingleGlbAsset = React.forwardRef<
     return material;
   }, [contextSize]);
   const outlineRef = React.useRef<THREE.Group>(null);
-  const hoveredRef = React.useContext(HoverableContext)!;
-  const viewer = React.useContext(ViewerContext)!;
+  const hoverContext = React.useContext(HoverableContext)!;
   useFrame(() => {
     if (outlineRef.current === null) return;
-    outlineRef.current.visible = hoveredRef.current.isHovered;
+    outlineRef.current.visible = hoverContext.state.current.isHovered;
   });
-  const clickable =
-    viewer.useSceneTree((state) => state[message.name]?.clickable) ?? false;
+  const clickable = hoverContext.clickable;
 
   if (!gltf) return null;
 

--- a/src/viser/client/src/mesh/SkinnedMesh.tsx
+++ b/src/viser/client/src/mesh/SkinnedMesh.tsx
@@ -206,7 +206,9 @@ export const SkinnedMesh = React.forwardRef<
       receiveShadow={message.props.receive_shadow}
       frustumCulled={false}
     >
-      <OutlinesIfHovered alwaysMounted />
+      <OutlinesIfHovered
+        enableCreaseAngle={geometry.attributes.position.count < 1024}
+      />
       {children}
     </skinnedMesh>
   );


### PR DESCRIPTION
For `add_mesh_simple()`, it turns out that a large amount of client-side overhead is caused by hover outline computation, specifically when `creaseAngle=pi`. This is true even for meshes that aren't clickable, where hover outlines are never shown.

This PR makes two changes:
- Sets `creaseAngle=0.0` for outlines in meshes with many vertices. Crease computation is CPU-intensive and was causing Viser to hang for several seconds on some meshes.
- Avoids creating outline objects unless meshes actually have click handlers attached.