### PR TITLE
Remove host == '0.0.0.0' condition

### DIFF
--- a/src/viser/_viser.py
+++ b/src/viser/_viser.py
@@ -755,15 +755,8 @@ class ViserServer(DeprecatedAttributeShim if not TYPE_CHECKING else object):
 
         # Form status print.
         port = server._port  # Port may have changed.
-        if host == "0.0.0.0":
-            # 0.0.0.0 is not a real IP and people are often confused by it;
-            # we'll just print localhost. This is questionable from a security
-            # perspective, but probably fine for our use cases.
-            http_url = f"http://localhost:{port}"
-            ws_url = f"ws://localhost:{port}"
-        else:
-            http_url = f"http://{host}:{port}"
-            ws_url = f"ws://{host}:{port}"
+        http_url = f"http://{host}:{port}"
+        ws_url = f"ws://{host}:{port}"
         table = Table(
             title=None,
             show_header=False,


### PR DESCRIPTION
This PR removes the special condition for `host == 0.0.0.0` that changes it to `localhost`. `0.0.0.0` and `localhost` are not the same.

Copied straight from google

> localhost:
This is a hostname that typically resolves to the loopback address (127.0.0.1 for IPv4, and ::1 for IPv6). It provides a more user-friendly and protocol-agnostic way to refer to the local machine. When a service binds to localhost, it generally supports both IPv4 and IPv6 loopback, depending on the system's configuration.
>
>0.0.0.0:
This special IP address, when used as a binding address for a service, signifies "all available network interfaces." If a service binds to 0.0.0.0, it will listen for incoming connections on all IP addresses configured on the local machine, including the loopback address (127.0.0.1) and any addresses assigned to physical network cards. This makes the service accessible from other machines on the network, not just the local host.

The key statement there about `0.0.0.0` is 
> This makes the service accessible from other machines on the network, not just the local host.
 
 I think it is best not to make any changes to the desired host value. If people get confused by `0.0.0.0` that is on them. If someone wants to set the host to `0.0.0.0` and not to `localhost`, they should be able to.