### PR TITLE
Unregister `atexit` callback after `.stop()`

### DIFF
--- a/src/viser/infra/_infra.py
+++ b/src/viser/infra/_infra.py
@@ -286,6 +286,9 @@ class WebsockServer(WebsockMessageHandler):
         assert self._stop_event is not None
         assert self._server_thread is not None
 
+        # Unregister the atexit handler to prevent double-stop
+        atexit.unregister(self.stop)
+
         # Signal the background thread to stop.
         self._background_event_loop.call_soon_threadsafe(self._stop_event.set)
 


### PR DESCRIPTION
Fixes #582, thanks @1st-username!