### PR TITLE
Improve startup overhead by bumping `InstancedMesh2`

### DIFF
--- a/src/viser/client/package-lock.json
+++ b/src/viser/client/package-lock.json
@@ -19,7 +19,7 @@
         "@react-three/drei": "^10.7.3",
         "@react-three/fiber": "^9.3.0",
         "@tabler/icons-react": "^3.1.0",
-        "@three.ez/instanced-mesh": "^0.3.7",
+        "@three.ez/instanced-mesh": "^0.3.9",
         "@types/node": "^20.11.30",
         "@types/react": "^18.0.33",
         "@types/react-dom": "^18.0.11",
@@ -1955,9 +1955,9 @@
       }
     },
     "node_modules/@three.ez/instanced-mesh": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@three.ez/instanced-mesh/-/instanced-mesh-0.3.7.tgz",
-      "integrity": "sha512-G+X47ICLWRga0pZV+t7Fr6wQ82MEfasH4LobnwE48MukpjMJ7+Mh2a94sgj/fzS6KKgFs+15RxsR9Kq5tLMPKg==",
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/@three.ez/instanced-mesh/-/instanced-mesh-0.3.9.tgz",
+      "integrity": "sha512-tSAsIEz9qeSvHTHSm1isd9UJ8KiaakDCqLrUE8O51FTbWzqQhi/ezNOPFpGTE+JIAekfi7+912FczCOS9WExrg==",
       "license": "MIT",
       "dependencies": {
         "bvh.js": "^0.0.13"

--- a/src/viser/client/package.json
+++ b/src/viser/client/package.json
@@ -14,7 +14,7 @@
     "@react-three/drei": "^10.7.3",
     "@react-three/fiber": "^9.3.0",
     "@tabler/icons-react": "^3.1.0",
-    "@three.ez/instanced-mesh": "^0.3.7",
+    "@three.ez/instanced-mesh": "^0.3.9",
     "@types/node": "^20.11.30",
     "@types/react": "^18.0.33",
     "@types/react-dom": "^18.0.11",


### PR DESCRIPTION
Improves startup overhead when batched meshes are used by 30%~40%. Thanks @agargaro!